### PR TITLE
Build Abseil dependency in CI.

### DIFF
--- a/Dockerfile.kinetic
+++ b/Dockerfile.kinetic
@@ -41,7 +41,8 @@ COPY cartographer_rviz/package.xml catkin_ws/src/cartographer_ros/cartographer_r
 COPY scripts/install_debs.sh cartographer_ros/scripts/
 RUN cartographer_ros/scripts/install_debs.sh && rm -rf /var/lib/apt/lists/*
 
-# Install proto3.
+# Install Abseil and proto3.
+RUN /catkin_ws/src/cartographer/scripts/install_abseil.sh
 RUN /catkin_ws/src/cartographer/scripts/install_proto3.sh
 
 # Build, install, and test all packages individually to allow caching. The

--- a/Dockerfile.melodic
+++ b/Dockerfile.melodic
@@ -41,7 +41,8 @@ COPY cartographer_rviz/package.xml catkin_ws/src/cartographer_ros/cartographer_r
 COPY scripts/install_debs.sh cartographer_ros/scripts/
 RUN cartographer_ros/scripts/install_debs.sh && rm -rf /var/lib/apt/lists/*
 
-# Install proto3.
+# Install Abseil and proto3.
+RUN /catkin_ws/src/cartographer/scripts/install_abseil.sh
 RUN /catkin_ws/src/cartographer/scripts/install_proto3.sh
 
 # Build, install, and test all packages individually to allow caching. The

--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -54,7 +54,7 @@ find_package(catkin REQUIRED COMPONENTS ${PACKAGE_DEPENDENCIES})
 
 include(FindPkgConfig)
 
-find_package(Abseil REQUIRED)
+find_package(absl REQUIRED)
 find_package(LuaGoogle REQUIRED)
 find_package(Eigen3 REQUIRED)
 

--- a/cartographer_rviz/CMakeLists.txt
+++ b/cartographer_rviz/CMakeLists.txt
@@ -33,7 +33,7 @@ find_package(cartographer REQUIRED)
 include("${CARTOGRAPHER_CMAKE_DIR}/functions.cmake")
 google_initialize_cartographer_project()
 
-find_package(Abseil REQUIRED)
+find_package(absl REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(catkin REQUIRED COMPONENTS ${PACKAGE_DEPENDENCIES})
 

--- a/scripts/install_debs.sh
+++ b/scripts/install_debs.sh
@@ -17,13 +17,10 @@
 set -o errexit
 set -o verbose
 
-# Install CMake 3.2 for Ubuntu Trusty and Debian Jessie.
+# Install CMake 3.2 for Debian Jessie.
 sudo apt-get update
 sudo apt-get install lsb-release -y
-if [[ "$(lsb_release -sc)" = "trusty" ]]
-then
-  sudo apt-get install cmake3 -y
-elif [[ "$(lsb_release -sc)" = "jessie" ]]
+if [[ "$(lsb_release -sc)" = "jessie" ]]
 then
   sudo sh -c "echo 'deb http://ftp.debian.org/debian jessie-backports main' >> /etc/apt/sources.list"
   sudo apt-get update
@@ -36,9 +33,9 @@ fi
 
 cd catkin_ws
 
-# Install Ninja.
+# Install Ninja and stow.
 apt-get update
-apt-get install -y ninja-build
+apt-get install -y ninja-build stow
 
 # Install rosdep dependencies.
 rosdep update


### PR DESCRIPTION
cartographer-project/cartographer#1711 removed
building Abseil from the Cartographer library.
We follow here the same approach as in
cartographer CI.

An alternative approach which is now possible is
adding an Abseil package for catkin and depending
on that.

Signed-off-by: Wolfgang Hess <whess@lyft.com>