### PR TITLE
Add flag to round the occupancy grid values to the trinary interpretation

### DIFF
--- a/cartographer_ros/cartographer_ros/msg_conversion.h
+++ b/cartographer_ros/cartographer_ros/msg_conversion.h
@@ -87,7 +87,7 @@ cartographer::transform::Rigid3d ComputeLocalFrameFromLatLong(double latitude,
 std::unique_ptr<nav_msgs::OccupancyGrid> CreateOccupancyGridMsg(
     const cartographer::io::PaintSubmapSlicesResult& painted_slices,
     const double resolution, const std::string& frame_id,
-    const ros::Time& time);
+    const ros::Time& time, bool trinary_interpretation = false);
 
 }  // namespace cartographer_ros
 

--- a/cartographer_ros/cartographer_ros/node.h
+++ b/cartographer_ros/cartographer_ros/node.h
@@ -58,7 +58,7 @@ class Node {
  public:
   Node(const NodeOptions& node_options,
        std::unique_ptr<cartographer::mapping::MapBuilderInterface> map_builder,
-       tf2_ros::Buffer* tf_buffer, bool collect_metrics);
+       tf2_ros::Buffer* tf_buffer, bool collect_metrics, const double transform_tolerance);
   ~Node();
 
   Node(const Node&) = delete;
@@ -184,6 +184,7 @@ class Node {
   MapBuilderBridge map_builder_bridge_ GUARDED_BY(mutex_);
 
   ::ros::NodeHandle node_handle_;
+  ::ros::Duration transform_tolerance_;
   ::ros::Publisher submap_list_publisher_;
   ::ros::Publisher trajectory_node_list_publisher_;
   ::ros::Publisher landmark_poses_list_publisher_;

--- a/cartographer_ros/cartographer_ros/node_main.cc
+++ b/cartographer_ros/cartographer_ros/node_main.cc
@@ -25,6 +25,8 @@
 DEFINE_bool(collect_metrics, false,
             "Activates the collection of runtime metrics. If activated, the "
             "metrics can be accessed via a ROS service.");
+DEFINE_double(transform_tolerance, 0.0,
+              "Time tolerance to apply to transform stamp.");
 DEFINE_string(configuration_directory, "",
               "First directory in which configuration files are searched, "
               "second is always the Cartographer installation to allow "
@@ -59,7 +61,7 @@ void Run() {
   auto map_builder = absl::make_unique<cartographer::mapping::MapBuilder>(
       node_options.map_builder_options);
   Node node(node_options, std::move(map_builder), &tf_buffer,
-            FLAGS_collect_metrics);
+            FLAGS_collect_metrics, FLAGS_transform_tolerance);
   if (!FLAGS_load_state_filename.empty()) {
     node.LoadState(FLAGS_load_state_filename, FLAGS_load_frozen_state);
   }

--- a/cartographer_ros/cartographer_ros/offline_node.cc
+++ b/cartographer_ros/cartographer_ros/offline_node.cc
@@ -38,6 +38,8 @@
 DEFINE_bool(collect_metrics, false,
             "Activates the collection of runtime metrics. If activated, the "
             "metrics can be accessed via a ROS service.");
+DEFINE_double(transform_tolerance, 0.0,
+              "Time tolerance to apply to transform stamp.");
 DEFINE_string(configuration_directory, "",
               "First directory in which configuration files are searched, "
               "second is always the Cartographer installation to allow "
@@ -143,7 +145,7 @@ void RunOfflineNode(const MapBuilderFactory& map_builder_factory) {
   tf_buffer.setUsingDedicatedThread(true);
 
   Node node(node_options, std::move(map_builder), &tf_buffer,
-            FLAGS_collect_metrics);
+            FLAGS_collect_metrics, FLAGS_transform_tolerance);
   if (!FLAGS_load_state_filename.empty()) {
     node.LoadState(FLAGS_load_state_filename, FLAGS_load_frozen_state);
   }

--- a/cartographer_ros/cartographer_ros/pbstream_map_publisher_main.cc
+++ b/cartographer_ros/cartographer_ros/pbstream_map_publisher_main.cc
@@ -39,12 +39,15 @@ DEFINE_string(pbstream_filename, "",
 DEFINE_string(map_topic, "map", "Name of the published map topic.");
 DEFINE_string(map_frame_id, "map", "Frame ID of the published map.");
 DEFINE_double(resolution, 0.05, "Resolution of a grid cell in the drawn map.");
+DEFINE_bool(trinary_interpretation, false,
+            "Publish trinary interpretation of the occupancy grid.");
 
 namespace cartographer_ros {
 namespace {
 
 std::unique_ptr<nav_msgs::OccupancyGrid> LoadOccupancyGridMsg(
-    const std::string& pbstream_filename, const double resolution) {
+    const std::string& pbstream_filename, const double resolution,
+    bool trinary_interpretation) {
   ::cartographer::io::ProtoStreamReader reader(pbstream_filename);
   ::cartographer::io::ProtoStreamDeserializer deserializer(&reader);
 
@@ -60,13 +63,14 @@ std::unique_ptr<nav_msgs::OccupancyGrid> LoadOccupancyGridMsg(
   const auto painted_slices =
       ::cartographer::io::PaintSubmapSlices(submap_slices, resolution);
   return CreateOccupancyGridMsg(painted_slices, resolution, FLAGS_map_frame_id,
-                                ros::Time::now());
+                                ros::Time::now(), trinary_interpretation);
 }
 
 void Run(const std::string& pbstream_filename, const std::string& map_topic,
-         const std::string& map_frame_id, const double resolution) {
+         const std::string& map_frame_id, const double resolution,
+         bool trinary_interpretation) {
   std::unique_ptr<nav_msgs::OccupancyGrid> msg_ptr =
-      LoadOccupancyGridMsg(pbstream_filename, resolution);
+      LoadOccupancyGridMsg(pbstream_filename, resolution, trinary_interpretation);
 
   ::ros::NodeHandle node_handle("");
   ::ros::Publisher pub = node_handle.advertise<nav_msgs::OccupancyGrid>(
@@ -95,5 +99,5 @@ int main(int argc, char** argv) {
   cartographer_ros::ScopedRosLogSink ros_log_sink;
 
   ::cartographer_ros::Run(FLAGS_pbstream_filename, FLAGS_map_topic,
-                          FLAGS_map_frame_id, FLAGS_resolution);
+                          FLAGS_map_frame_id, FLAGS_resolution, FLAGS_trinary_interpretation);
 }


### PR DESCRIPTION
- ROS navigation stack does not work correctly with the map currently published by Cartographer ROS.
- Autonomous exploration packages are not able to detect frontiers.
- MoveBase complains about TF needing to extrapolate into the future when running autonomous exploration nodes.
--------
- For the first two bullets, I added a FLAG `trinary_interpretation` into `occupancy_grid_node_main` and `pbstream_map_publisher_main` to round the values into `0` or `100` based on default `phit` and `pmiss`.
- For the third bullet, I added a FLAG to `node_main` and `offline_node` that allows setting a tolerance to the TF message. This is something similar to what AMCL and GMapping do.

Signed-off-by: Christian Barcelo <christianbarcelo@ekumenlabs.com>