### PR TITLE
Remove support for Debian Jessie.

### DIFF
--- a/scripts/install_debs.sh
+++ b/scripts/install_debs.sh
@@ -17,25 +17,13 @@
 set -o errexit
 set -o verbose
 
-# Install CMake 3.2 for Debian Jessie.
+# Install CMake, Ninja, stow.
 sudo apt-get update
-sudo apt-get install lsb-release -y
-if [[ "$(lsb_release -sc)" = "jessie" ]]
-then
-  sudo sh -c "echo 'deb http://ftp.debian.org/debian jessie-backports main' >> /etc/apt/sources.list"
-  sudo apt-get update
-  sudo apt-get -t jessie-backports install cmake -y
-else
-  sudo apt-get install cmake -y
-fi
+sudo apt-get install -y lsb-release cmake ninja-build stow
 
 . /opt/ros/${ROS_DISTRO}/setup.sh
 
 cd catkin_ws
-
-# Install Ninja and stow.
-apt-get update
-apt-get install -y ninja-build stow
 
 # Install rosdep dependencies.
 rosdep update


### PR DESCRIPTION
It has reached end-of-life with the
end of LTS on June 30, 2020.

Signed-off-by: Wolfgang Hess <whess@lyft.com>