### PR TITLE
Remove unnecessary bottlenecks from Dockerfiles to speed up CI.

### DIFF
--- a/Dockerfile.kinetic
+++ b/Dockerfile.kinetic
@@ -20,7 +20,7 @@ ARG CARTOGRAPHER_VERSION=master
 ARG github_token
 
 # Xenial's base image doesn't ship with sudo.
-RUN apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y sudo
 
 # First, we invalidate the entire cache if cartographer-project/cartographer has
 # changed. This file's content changes whenever master changes. See:
@@ -39,7 +39,7 @@ COPY cartographer_ros/package.xml catkin_ws/src/cartographer_ros/cartographer_ro
 COPY cartographer_ros_msgs/package.xml catkin_ws/src/cartographer_ros/cartographer_ros_msgs/
 COPY cartographer_rviz/package.xml catkin_ws/src/cartographer_ros/cartographer_rviz/
 COPY scripts/install_debs.sh cartographer_ros/scripts/
-RUN cartographer_ros/scripts/install_debs.sh && rm -rf /var/lib/apt/lists/*
+RUN cartographer_ros/scripts/install_debs.sh
 
 # Install Abseil and proto3.
 RUN /catkin_ws/src/cartographer/scripts/install_abseil.sh
@@ -75,6 +75,8 @@ RUN cartographer_ros/scripts/install.sh --pkg cartographer_rviz && \
     cartographer_ros/scripts/catkin_test_results.sh build_isolated/cartographer_rviz
 
 COPY scripts/ros_entrypoint.sh /
+
+RUN rm -rf /var/lib/apt/lists/*
 # A BTRFS bug may prevent us from cleaning up these directories.
 # https://btrfs.wiki.kernel.org/index.php/Problem_FAQ#I_cannot_delete_an_empty_directory
 RUN rm -rf cartographer_ros catkin_ws || true

--- a/Dockerfile.kinetic
+++ b/Dockerfile.kinetic
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ros:kinetic
+FROM osrf/ros:kinetic-desktop
 
 ARG CARTOGRAPHER_VERSION=master
 

--- a/Dockerfile.melodic
+++ b/Dockerfile.melodic
@@ -43,7 +43,6 @@ RUN cartographer_ros/scripts/install_debs.sh
 
 # Install Abseil and proto3.
 RUN /catkin_ws/src/cartographer/scripts/install_abseil.sh
-RUN /catkin_ws/src/cartographer/scripts/install_proto3.sh
 
 # Build, install, and test all packages individually to allow caching. The
 # ordering of these steps must match the topological package ordering as

--- a/Dockerfile.melodic
+++ b/Dockerfile.melodic
@@ -20,7 +20,7 @@ ARG CARTOGRAPHER_VERSION=master
 ARG github_token
 
 # Bionic's base image doesn't ship with sudo.
-RUN apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y sudo
 
 # First, we invalidate the entire cache if cartographer-project/cartographer has
 # changed. This file's content changes whenever master changes. See:
@@ -39,7 +39,7 @@ COPY cartographer_ros/package.xml catkin_ws/src/cartographer_ros/cartographer_ro
 COPY cartographer_ros_msgs/package.xml catkin_ws/src/cartographer_ros/cartographer_ros_msgs/
 COPY cartographer_rviz/package.xml catkin_ws/src/cartographer_ros/cartographer_rviz/
 COPY scripts/install_debs.sh cartographer_ros/scripts/
-RUN cartographer_ros/scripts/install_debs.sh && rm -rf /var/lib/apt/lists/*
+RUN cartographer_ros/scripts/install_debs.sh
 
 # Install Abseil and proto3.
 RUN /catkin_ws/src/cartographer/scripts/install_abseil.sh
@@ -75,6 +75,8 @@ RUN cartographer_ros/scripts/install.sh --pkg cartographer_rviz && \
     cartographer_ros/scripts/catkin_test_results.sh build_isolated/cartographer_rviz
 
 COPY scripts/ros_entrypoint.sh /
+
+RUN rm -rf /var/lib/apt/lists/*
 # A BTRFS bug may prevent us from cleaning up these directories.
 # https://btrfs.wiki.kernel.org/index.php/Problem_FAQ#I_cannot_delete_an_empty_directory
 RUN rm -rf cartographer_ros catkin_ws || true

--- a/Dockerfile.melodic
+++ b/Dockerfile.melodic
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ros:melodic
+FROM osrf/ros:melodic-desktop
 
 ARG CARTOGRAPHER_VERSION=master
 

--- a/Dockerfile.melodic
+++ b/Dockerfile.melodic
@@ -56,7 +56,7 @@ RUN cartographer_ros/scripts/install.sh --pkg cartographer_ros_msgs && \
         --catkin-make-args run_tests && \
     cartographer_ros/scripts/catkin_test_results.sh build_isolated/cartographer_ros_msgs
 
-RUN cartographer_ros/scripts/install.sh --pkg ceres-solver
+RUN apt-get install -y libceres-dev
 
 RUN cartographer_ros/scripts/install.sh --pkg cartographer && \
     cartographer_ros/scripts/install.sh --pkg cartographer --make-args test

--- a/Dockerfile.melodic
+++ b/Dockerfile.melodic
@@ -41,7 +41,7 @@ COPY cartographer_rviz/package.xml catkin_ws/src/cartographer_ros/cartographer_r
 COPY scripts/install_debs.sh cartographer_ros/scripts/
 RUN cartographer_ros/scripts/install_debs.sh
 
-# Install Abseil and proto3.
+# Install Abseil.
 RUN /catkin_ws/src/cartographer/scripts/install_abseil.sh
 
 # Build, install, and test all packages individually to allow caching. The

--- a/Dockerfile.noetic
+++ b/Dockerfile.noetic
@@ -45,7 +45,7 @@ COPY cartographer_rviz/package.xml catkin_ws/src/cartographer_ros/cartographer_r
 COPY scripts/install_debs.sh cartographer_ros/scripts/
 RUN cartographer_ros/scripts/install_debs.sh
 
-# Install Abseil and proto3.
+# Install Abseil.
 RUN /catkin_ws/src/cartographer/scripts/install_abseil.sh
 
 # Build, install, and test all packages individually to allow caching. The

--- a/Dockerfile.noetic
+++ b/Dockerfile.noetic
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ros:noetic
+FROM osrf/ros:noetic-desktop
 
 ARG CARTOGRAPHER_VERSION=master
 

--- a/Dockerfile.noetic
+++ b/Dockerfile.noetic
@@ -47,7 +47,6 @@ RUN cartographer_ros/scripts/install_debs.sh
 
 # Install Abseil and proto3.
 RUN /catkin_ws/src/cartographer/scripts/install_abseil.sh
-RUN /catkin_ws/src/cartographer/scripts/install_proto3.sh
 
 # Build, install, and test all packages individually to allow caching. The
 # ordering of these steps must match the topological package ordering as

--- a/Dockerfile.noetic
+++ b/Dockerfile.noetic
@@ -60,7 +60,7 @@ RUN cartographer_ros/scripts/install.sh --pkg cartographer_ros_msgs && \
         --catkin-make-args run_tests && \
     cartographer_ros/scripts/catkin_test_results.sh build_isolated/cartographer_ros_msgs
 
-RUN cartographer_ros/scripts/install.sh --pkg ceres-solver
+RUN apt-get install -y libceres-dev
 
 RUN cartographer_ros/scripts/install.sh --pkg cartographer && \
     cartographer_ros/scripts/install.sh --pkg cartographer --make-args test

--- a/Dockerfile.noetic
+++ b/Dockerfile.noetic
@@ -24,7 +24,7 @@ ARG github_token
 ARG DEBIAN_FRONTEND=noninteractive
 
 # ROS Noetic's base image doesn't ship with sudo and git.
-RUN apt-get update && apt-get install -y sudo git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y sudo git
 
 # First, we invalidate the entire cache if cartographer-project/cartographer has
 # changed. This file's content changes whenever master changes. See:
@@ -43,7 +43,7 @@ COPY cartographer_ros/package.xml catkin_ws/src/cartographer_ros/cartographer_ro
 COPY cartographer_ros_msgs/package.xml catkin_ws/src/cartographer_ros/cartographer_ros_msgs/
 COPY cartographer_rviz/package.xml catkin_ws/src/cartographer_ros/cartographer_rviz/
 COPY scripts/install_debs.sh cartographer_ros/scripts/
-RUN cartographer_ros/scripts/install_debs.sh && rm -rf /var/lib/apt/lists/*
+RUN cartographer_ros/scripts/install_debs.sh
 
 # Install Abseil and proto3.
 RUN /catkin_ws/src/cartographer/scripts/install_abseil.sh
@@ -79,6 +79,8 @@ RUN cartographer_ros/scripts/install.sh --pkg cartographer_rviz && \
     cartographer_ros/scripts/catkin_test_results.sh build_isolated/cartographer_rviz
 
 COPY scripts/ros_entrypoint.sh /
+
+RUN rm -rf /var/lib/apt/lists/*
 # A BTRFS bug may prevent us from cleaning up these directories.
 # https://btrfs.wiki.kernel.org/index.php/Problem_FAQ#I_cannot_delete_an_empty_directory
 RUN rm -rf cartographer_ros catkin_ws || true


### PR DESCRIPTION
This should solve #1506.

- Use osrf/ros-<distro>-desktop as base image for CI
The basic ROS base image requires rosdep to install packages with many
dependencies, e.g. rviz. Using the desktop base image should speed up CI
because it has a good overlap with what we need and only little extra stuff.
- Remove apt list only after installing everything.
- Don't build protobuf 3 from source on Ubuntu 18 & 20.
It should come with rosdep. Only on Ubuntu 16 we need to build manually
because it ships with Protobuf 2.
-  No need to build Ceres from source on Ubuntu 18 & 20. 
The versions are greater or equal to 1.13, which is the one specified in
the source build script. The apt packages should work just fine.

The cartographer library is built from source in all cases, which is good to
ensure that we always test compatibility with the latest version of it.