### PR TITLE
Fix Sphinx documentation errors & warnings.

### DIFF
--- a/docs/source/assets_writer.rst
+++ b/docs/source/assets_writer.rst
@@ -80,8 +80,8 @@ For the last example, if you specify ``points.ply`` in the pipeline configuratio
 Configuration
 -------------
 
-The assets writer is modeled as a pipeline of `PointsProcessor`_s.
-`PointsBatch`_\ s flow through each processor and they all have the chance to modify the ``PointsBatch`` before passing it on.
+The assets writer is modeled as a pipeline of `PointsProcessor`_ steps.
+`PointsBatch`_ data flows through each processor and they all have the chance to modify the ``PointsBatch`` before passing it on.
 
 .. _PointsProcessor: https://github.com/cartographer-project/cartographer/blob/30f7de1a325d6604c780f2f74d9a345ec369d12d/cartographer/io/points_processor.h
 .. _PointsBatch: https://github.com/cartographer-project/cartographer/blob/30f7de1a325d6604c780f2f74d9a345ec369d12d/cartographer/io/points_batch.h

--- a/docs/source/compilation.rst
+++ b/docs/source/compilation.rst
@@ -76,6 +76,7 @@ If you build cartographer from master. Change/remove the version in the cartogra
 Additionally, uninstall the ros abseil-cpp using
 
 .. code-block:: bash
+
    sudo apt-get remove ros-${ROS_DISTRO}-abseil-cpp 
 
 Build and install.

--- a/docs/source/demos.rst
+++ b/docs/source/demos.rst
@@ -81,7 +81,7 @@ Generate the map (wait until cartographer_offline_node finishes) and then run pu
        bag_filename:=${HOME}/Downloads/b3-2016-04-05-15-52-20.bag
 
 Static landmarks
-========
+================
 
   .. raw:: html
 


### PR DESCRIPTION
Fixes broken links, code blocks and other things that
`sphinx-build docs/source docs/out -E` complained about.