### PR TITLE
Default to master in rosinstall (fixes #1122).

### DIFF
--- a/cartographer_ros.rosinstall
+++ b/cartographer_ros.rosinstall
@@ -1,3 +1,3 @@
-- git: {local-name: cartographer, uri: 'https://github.com/cartographer-project/cartographer.git', version: '1.0.0'}
-- git: {local-name: cartographer_ros, uri: 'https://github.com/cartographer-project/cartographer_ros.git', version: '1.0.0'}
+- git: {local-name: cartographer, uri: 'https://github.com/cartographer-project/cartographer.git', version: 'master'}
+- git: {local-name: cartographer_ros, uri: 'https://github.com/cartographer-project/cartographer_ros.git', version: 'master'}
 - git: {local-name: ceres-solver, uri: 'https://ceres-solver.googlesource.com/ceres-solver.git', version: '1.13.0'}

--- a/docs/source/compilation.rst
+++ b/docs/source/compilation.rst
@@ -71,7 +71,8 @@ The command 'sudo rosdep init' will print an error if you have already executed 
     rosdep update
     rosdep install --from-paths src --ignore-src --rosdistro=${ROS_DISTRO} -y
 
-If you build cartographer from master. Change/remove the version in the cartographer_ros.rosinstall.
+This builds Cartographer from the latest HEAD of the master branch.
+If you want a specific version, you need to change the version in the cartographer_ros.rosinstall.
 
 Additionally, uninstall the ros abseil-cpp using
 

--- a/scripts/prepare_catkin_workspace.sh
+++ b/scripts/prepare_catkin_workspace.sh
@@ -26,6 +26,10 @@ wstool init
 
 # Merge the cartographer_ros.rosinstall file and fetch code for dependencies.
 wstool merge ../../cartographer_ros/cartographer_ros.rosinstall
-wstool set cartographer -v ${CARTOGRAPHER_VERSION} -y
+# We default to master and wstool seems to have a bug when it's being set twice.
+# TODO(MichaelGrupp): wstool is unmaintained, use vcstool.
+if [ ${CARTOGRAPHER_VERSION} != "master" ]; then
+  wstool set cartographer -v ${CARTOGRAPHER_VERSION} -y
+fi
 wstool remove cartographer_ros
 wstool update


### PR DESCRIPTION
This makes much more sense than 1.0.0, which is counter-intuitive.

If someone is building from source they usually do it to build the
latest bleeding-edge version.

Signed-off-by: Michael Grupp <grupp@magazino.eu>