### PR TITLE
Remove ceres-solver from cartographer_ros.rosinstall.

### DIFF
--- a/cartographer_ros.rosinstall
+++ b/cartographer_ros.rosinstall
@@ -1,3 +1,2 @@
 - git: {local-name: cartographer, uri: 'https://github.com/cartographer-project/cartographer.git', version: 'master'}
 - git: {local-name: cartographer_ros, uri: 'https://github.com/cartographer-project/cartographer_ros.git', version: 'master'}
-- git: {local-name: ceres-solver, uri: 'https://ceres-solver.googlesource.com/ceres-solver.git', version: '1.13.0'}


### PR DESCRIPTION
Recent versions no longer build ceres-solver and instead
depend on libceres-dev. See also #1518.

Signed-off-by: Wolfgang Hess <whess@lyft.com>