### PR TITLE
Improve CONTRIBUTING.md and add a pull request template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,2 @@
+Want to contribute? Great! Make sure you've read and understood
+[CONTRIBUTING.md](https://github.com/cartographer-project/cartographer_ros/blob/master/CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,5 +27,25 @@ You can sign-off a commit via `git commit -s`.
 ### Code reviews
 
 All submissions, including submissions by project members, require review.
-We use GitHub pull requests for this purpose.
+We use GitHub pull requests for this purpose. Make sure you've read,
+understood and considered all the points below before creating your PR.
 
+#### Style guide
+
+C++ code should adhere to the
+[Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
+You can handle the formatting part of the style guide via `git clang-format`.
+
+#### Best practices
+
+When preparing your PR and also during the code review make sure to follow
+[best practices](https://google.github.io/eng-practices/review/developer/).
+Most importantly, keep your PR under 200 lines of code and address a single
+concern.
+
+#### Testing
+
+- Add unit tests and documentation (these do not count toward your 200 lines).
+- Run tests as appropriate, e.g. `docker build . -t cartographer:noetic -f Dockerfile.noetic`.
+- Keep rebasing (or merging) of master branch to a minimum. It triggers Travis
+  runs for every update which blocks merging of other changes.


### PR DESCRIPTION
This is similar to cartographer-project/cartographer#1780, but
- we add a pull request template (there was none before)
- we refer to cartographer_ros CONTRIBUTING.md
- we give different instructions to execute cartographer_ros tests

Signed-off-by: Wolfgang Hess <whess@lyft.com>