### PR TITLE
Fixing typo in the docs

### DIFF
--- a/docs/source/assets_writer.rst
+++ b/docs/source/assets_writer.rst
@@ -62,7 +62,7 @@ When running as an online node, Cartographer doesn't know when your bag (or sens
 
    # Ask Cartographer to serialize its current state.
    # (press tab to quickly expand the parameter syntax)
-   rosservice call /write_state "{filename: '${HOME}/Downloads/b3-2016-04-05-14-14-00.bag.pbstream', include_unfinished_submaps: 'true'}"
+   rosservice call /write_state "{filename: '${HOME}/Downloads/b3-2016-04-05-14-14-00.bag.pbstream', include_unfinished_submaps: "true"}"
 
 Once you've retrieved your ``.pbstream`` file, you can run the assets writer with the `sample pipeline`_ for the 3D backpack:
 


### PR DESCRIPTION
Fixing a typo
The output before changing
```
ERROR: Unable to send request. One of the fields has an incorrect type:
  field include_unfinished_submaps is not a bool

srv file:
string filename
bool include_unfinished_submaps
---
cartographer_ros_msgs/StatusResponse status
  uint8 code
  string message
```
After changing
```
status:
  code: 0
  message: "State written to '/home/mohamed/Downloads/b3-2016-04-05-14-14-00.bag.pbstream'."

```
