### PR TITLE
ROS2 rolling/galactic conversion

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -12,82 +12,62 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8.12)  # Ships with Ubuntu 14.04 (Trusty)
+cmake_minimum_required(VERSION 3.5)
 
 project(cartographer_ros)
 
-set(PACKAGE_DEPENDENCIES
-  cartographer_ros_msgs
-  geometry_msgs
-  message_runtime
-  nav_msgs
-  pcl_conversions
-  rosbag
-  roscpp
-  roslib
-  sensor_msgs
-  std_msgs
-  tf2
-  tf2_eigen
-  tf2_ros
-  urdf
-  visualization_msgs
-)
+find_package(ament_cmake REQUIRED)
 
-if(WIN32)
-  set(Boost_USE_STATIC_LIBS FALSE)
+# Default to C++17
+set(CMAKE_CXX_STANDARD 17)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra)
 endif()
-# For yet unknown reason, if Boost is find_packaged() after find_package(cartographer),
-# some Boost libraries including Thread are set to static, despite Boost_USE_STATIC_LIBS,
-# which causes linking problems on windows due to shared/static Thread clashing.
-# PCL also finds Boost. Work around by moving before find_package(cartographer).
-find_package(Boost REQUIRED COMPONENTS system iostreams)
-find_package(PCL REQUIRED COMPONENTS common)
+
+add_compile_options(-g)
 
 find_package(cartographer REQUIRED)
 include("${CARTOGRAPHER_CMAKE_DIR}/functions.cmake")
+set(BUILD_SHARED_LIBS OFF)
 option(BUILD_GRPC "build features that require Cartographer gRPC support" false)
+
 google_initialize_cartographer_project()
-google_enable_testing()
-set(CARTOGRAPHER_GMOCK_LIBRARIES ${GMOCK_LIBRARIES})
 
-find_package(catkin REQUIRED COMPONENTS ${PACKAGE_DEPENDENCIES})
-
-include(FindPkgConfig)
+find_package(cartographer_ros_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(pcl_conversions REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_eigen REQUIRED)
+find_package(tf2_msgs REQUIRED)
+find_package(visualization_msgs REQUIRED)
+find_package(rosbag2_compression REQUIRED)
+find_package(rosbag2_cpp REQUIRED)
+find_package(rosbag2_storage REQUIRED)
+find_package(backward_ros REQUIRED)
 
 find_package(absl REQUIRED)
 find_package(LuaGoogle REQUIRED)
+find_package(PCL REQUIRED COMPONENTS common)
 find_package(Eigen3 REQUIRED)
-
+find_package(urdf REQUIRED)
 find_package(urdfdom_headers REQUIRED)
+
 if(DEFINED urdfdom_headers_VERSION)
   if(${urdfdom_headers_VERSION} GREATER 0.4.1)
     add_definitions(-DURDFDOM_HEADERS_HAS_SHARED_PTR_DEFS)
   endif()
 endif()
 
+
 include_directories(
-  ${urdfdom_headers_INCLUDE_DIRS}
-)
-
-# Override Catkin's GTest configuration to use GMock.
-set(GTEST_FOUND TRUE)
-set(GTEST_INCLUDE_DIRS ${GMOCK_INCLUDE_DIRS})
-set(GTEST_LIBRARIES ${CARTOGRAPHER_GMOCK_LIBRARIES})
-
-catkin_package(
-  CATKIN_DEPENDS
-    ${PACKAGE_DEPENDENCIES}
-  DEPENDS
-    # TODO(damonkohler): This should be here but causes Catkin to abort because
-    # protobuf specifies a library '-lpthread' instead of just 'pthread'.
-    # CARTOGRAPHER
-    PCL
-    EIGEN3
-    Boost
-    urdfdom_headers
-  INCLUDE_DIRS "."
-  LIBRARIES ${PROJECT_NAME}
+  include
+  "."
 )
 
 file(GLOB_RECURSE ALL_SRCS "cartographer_ros/*.cc" "cartographer_ros/*.h")
@@ -101,9 +81,30 @@ if (NOT ${BUILD_GRPC})
   list(REMOVE_ITEM ALL_TESTS ${ALL_GRPC_FILES})
   list(REMOVE_ITEM ALL_EXECUTABLES ${ALL_GRPC_FILES})
 endif()
-add_library(${PROJECT_NAME} STATIC ${ALL_SRCS})
-add_subdirectory("cartographer_ros")
 
+add_library(${PROJECT_NAME} STATIC ${ALL_SRCS})
+ament_target_dependencies(${PROJECT_NAME} PUBLIC
+  backward_ros
+  cartographer
+  cartographer_ros_msgs
+  geometry_msgs
+  nav_msgs
+  pcl_conversions
+  rclcpp
+  sensor_msgs
+  std_msgs
+  tf2
+  tf2_eigen
+  tf2_msgs
+  tf2_ros
+  visualization_msgs
+  rosbag2_compression
+  rosbag2_cpp
+  rosbag2_storage
+  urdf
+  urdfdom_headers
+)
+add_subdirectory("cartographer_ros")
 target_link_libraries(${PROJECT_NAME} PUBLIC cartographer)
 
 # Lua
@@ -125,15 +126,17 @@ endforeach()
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
   "${EIGEN3_INCLUDE_DIR}")
 
-# Boost
+## YAML in ros2 1.0
+#target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${YAMLCPP_INCLUDE_DIRS})
+#target_link_libraries(${PROJECT_NAME} PUBLIC ${YAMLCPP_LIBRARIES})
+
+# Boost not in ros2
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
   "${Boost_INCLUDE_DIRS}")
 target_link_libraries(${PROJECT_NAME} PUBLIC ${Boost_LIBRARIES})
 
-# Catkin
-target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${catkin_INCLUDE_DIRS})
-target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES})
-add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+## URDFDOM in ros2 1.0
+target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${urdfdom_headers_INCLUDE_DIRS})
 
 # Add the binary directory first, so that port.h is included after it has
 # been generated.
@@ -147,51 +150,65 @@ set(TARGET_COMPILE_FLAGS "${TARGET_COMPILE_FLAGS} ${GOOG_CXX_FLAGS}")
 set_target_properties(${PROJECT_NAME} PROPERTIES
   COMPILE_FLAGS ${TARGET_COMPILE_FLAGS})
 
-if (CATKIN_ENABLE_TESTING)
-  foreach(TEST_SOURCE_FILENAME ${ALL_TESTS})
-    get_filename_component(TEST_NAME ${TEST_SOURCE_FILENAME} NAME_WE)
-    catkin_add_gtest(${TEST_NAME} ${TEST_SOURCE_FILENAME})
-    # catkin_add_gtest uses a plain (i.e. no PUBLIC/PRIVATE/INTERFACE) call to
-    # target_link_libraries. That forces us to do the same.
-    target_link_libraries(${TEST_NAME} ${GMOCK_LIBRARIES} ${GTEST_MAIN_LIBRARIES})
-    target_include_directories(${TEST_NAME} SYSTEM PUBLIC ${LUA_INCLUDE_DIR})
-    target_link_libraries(${TEST_NAME} ${LUA_LIBRARIES})
-    target_include_directories(${TEST_NAME} SYSTEM PUBLIC ${catkin_INCLUDE_DIRS})
-    target_link_libraries(${TEST_NAME} ${catkin_LIBRARIES})
-    add_dependencies(${TEST_NAME} ${catkin_EXPORTED_TARGETS})
-    target_link_libraries(${TEST_NAME} cartographer)
-    target_link_libraries(${TEST_NAME} ${PROJECT_NAME})
-    set_target_properties(${TEST_NAME} PROPERTIES COMPILE_FLAGS ${TARGET_COMPILE_FLAGS})
-    # Needed for dynamically linked GTest on Windows.
-    if (WIN32)
-      target_compile_definitions(${TEST_NAME} PUBLIC -DGTEST_LINKED_AS_SHARED_LIBRARY)
-    endif()
-  endforeach()
-endif()
+#if (CATKIN_ENABLE_TESTING)
+#  foreach(TEST_SOURCE_FILENAME ${ALL_TESTS})
+#    get_filename_component(TEST_NAME ${TEST_SOURCE_FILENAME} NAME_WE)
+#    catkin_add_gtest(${TEST_NAME} ${TEST_SOURCE_FILENAME})
+#    # catkin_add_gtest uses a plain (i.e. no PUBLIC/PRIVATE/INTERFACE) call to
+#    # target_link_libraries. That forces us to do the same.
+#    target_link_libraries(${TEST_NAME} ${GMOCK_LIBRARIES} ${GTEST_MAIN_LIBRARIES})
+#    target_include_directories(${TEST_NAME} SYSTEM PUBLIC ${LUA_INCLUDE_DIR})
+#    target_link_libraries(${TEST_NAME} ${LUA_LIBRARIES})
+#    target_include_directories(${TEST_NAME} SYSTEM PUBLIC ${catkin_INCLUDE_DIRS})
+#    target_link_libraries(${TEST_NAME} ${catkin_LIBRARIES})
+#    add_dependencies(${TEST_NAME} ${catkin_EXPORTED_TARGETS})
+#    target_link_libraries(${TEST_NAME} cartographer)
+#    target_link_libraries(${TEST_NAME} ${PROJECT_NAME})
+#    set_target_properties(${TEST_NAME} PROPERTIES COMPILE_FLAGS ${TARGET_COMPILE_FLAGS})
+#    # Needed for dynamically linked GTest on Windows.
+#    if (WIN32)
+#      target_compile_definitions(${TEST_NAME} PUBLIC -DGTEST_LINKED_AS_SHARED_LIBRARY)
+#    endif()
+#  endforeach()
+#endif()
 
-install(DIRECTORY launch urdf configuration_files
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+install(DIRECTORY configuration_files
+  DESTINATION share/${PROJECT_NAME}/
 )
 
-install(PROGRAMS scripts/tf_remove_frames.py
-  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
+install(TARGETS
+  ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
 
-install(TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-)
 
-# Install source headers.
-file(GLOB_RECURSE HDRS "cartographer_ros/*.h")
-foreach(HDR ${HDRS})
-  file(RELATIVE_PATH REL_FIL ${PROJECT_SOURCE_DIR} ${HDR})
-  get_filename_component(INSTALL_DIR ${REL_FIL} DIRECTORY)
-  install(
-    FILES
-      ${HDR}
-    DESTINATION
-      include/${INSTALL_DIR}
-  )
-endforeach()
+# ros1 install
+#install(DIRECTORY launch urdf configuration_files
+#  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+#)
+
+#install(PROGRAMS scripts/tf_remove_frames.py
+#  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+#)
+
+#install(TARGETS ${PROJECT_NAME}
+#  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+#)
+
+## Install source headers.
+#file(GLOB_RECURSE HDRS "cartographer_ros/*.h")
+#foreach(HDR ${HDRS})
+#  file(RELATIVE_PATH REL_FIL ${PROJECT_SOURCE_DIR} ${HDR})
+#  get_filename_component(INSTALL_DIR ${REL_FIL} DIRECTORY)
+#  install(
+#    FILES
+#      ${HDR}
+#    DESTINATION
+#      include/${INSTALL_DIR}
+#  )
+#endforeach()
+
+ament_package()

--- a/cartographer_ros/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/cartographer_ros/CMakeLists.txt
@@ -12,39 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-google_binary(cartographer_assets_writer
-  SRCS
-    assets_writer_main.cc
-    ros_map_writing_points_processor.h
-    ros_map_writing_points_processor.cc
-)
-
-install(TARGETS cartographer_assets_writer
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
 google_binary(cartographer_node
   SRCS
     node_main.cc
-)
-
-install(TARGETS cartographer_node
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-google_binary(cartographer_offline_node
-  SRCS
-    offline_node_main.cc
-)
-
-install(TARGETS cartographer_offline_node
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 google_binary(cartographer_occupancy_grid_node
@@ -52,32 +22,16 @@ google_binary(cartographer_occupancy_grid_node
     occupancy_grid_node_main.cc
 )
 
-install(TARGETS cartographer_occupancy_grid_node
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-google_binary(cartographer_rosbag_validate
+google_binary(cartographer_offline_node
   SRCS
-    rosbag_validate_main.cc
+    offline_node_main.cc
 )
 
-install(TARGETS cartographer_rosbag_validate
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-google_binary(cartographer_pbstream_to_ros_map
+google_binary(cartographer_assets_writer
   SRCS
-    pbstream_to_ros_map_main.cc
-)
-
-install(TARGETS cartographer_pbstream_to_ros_map
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    assets_writer_main.cc
+    ros_map_writing_points_processor.h
+    ros_map_writing_points_processor.cc
 )
 
 google_binary(cartographer_pbstream_map_publisher
@@ -85,71 +39,59 @@ google_binary(cartographer_pbstream_map_publisher
     pbstream_map_publisher_main.cc
 )
 
-install(TARGETS cartographer_pbstream_map_publisher
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-google_binary(cartographer_dev_pbstream_trajectories_to_rosbag
+google_binary(cartographer_pbstream_to_ros_map
   SRCS
-  dev/pbstream_trajectories_to_rosbag_main.cc
+    pbstream_to_ros_map_main.cc
 )
 
-install(TARGETS cartographer_dev_pbstream_trajectories_to_rosbag
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-google_binary(cartographer_dev_rosbag_publisher
+google_binary(cartographer_rosbag_validate
   SRCS
-  dev/rosbag_publisher_main.cc
+    rosbag_validate_main.cc
 )
 
-install(TARGETS cartographer_dev_rosbag_publisher
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
+install(TARGETS
+  cartographer_node
+  cartographer_occupancy_grid_node
+  cartographer_offline_node
+  cartographer_assets_writer
+  cartographer_pbstream_map_publisher
+  cartographer_pbstream_to_ros_map
+  cartographer_rosbag_validate
+  DESTINATION lib/${PROJECT_NAME})
 
-google_binary(cartographer_dev_trajectory_comparison
-  SRCS
-  dev/trajectory_comparison_main.cc
-)
 
-install(TARGETS cartographer_dev_trajectory_comparison
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
+#google_binary(cartographer_dev_pbstream_trajectories_to_rosbag
+#  SRCS
+#  dev/pbstream_trajectories_to_rosbag_main.cc
+#)
 
-# TODO(cschuet): Add support for shared library case.
-if (${BUILD_GRPC})
-  google_binary(cartographer_grpc_node
-    SRCS
-      cartographer_grpc/node_grpc_main.cc
-  )
+#google_binary(cartographer_dev_rosbag_publisher
+#  SRCS
+#  dev/rosbag_publisher_main.cc
+#)
 
-  install(TARGETS cartographer_grpc_node
-    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-  )
 
-  google_binary(cartographer_grpc_offline_node
-    SRCS
-      cartographer_grpc/offline_node_grpc_main.cc
-  )
+#google_binary(cartographer_dev_trajectory_comparison
+#  SRCS
+#  dev/trajectory_comparison_main.cc
+#)
 
-  install(TARGETS cartographer_grpc_offline_node
-    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-  )
 
-  install(PROGRAMS
-    ../scripts/cartographer_grpc_server.sh
-    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-  )
-endif()
+## TODO(cschuet): Add support for shared library case.
+#if (${BUILD_GRPC})
+#  google_binary(cartographer_grpc_node
+#    SRCS
+#      cartographer_grpc/node_grpc_main.cc
+#  )
+
+
+#  google_binary(cartographer_grpc_offline_node
+#    SRCS
+#      cartographer_grpc/offline_node_grpc_main.cc
+#  )
+
+#  install(PROGRAMS
+#    ../scripts/cartographer_grpc_server.sh
+#    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+#  )
+#endif()

--- a/cartographer_ros/cartographer_ros/assets_writer.h
+++ b/cartographer_ros/cartographer_ros/assets_writer.h
@@ -21,6 +21,7 @@
 #include "cartographer/io/points_processor_pipeline_builder.h"
 #include "cartographer/mapping/proto/pose_graph.pb.h"
 #include "cartographer/mapping/proto/trajectory_builder_options.pb.h"
+#include <rclcpp/rclcpp.hpp>
 
 #ifndef CARTOGRAPHER_ROS_CARTOGRAPHER_ROS_ASSETS_WRITER_H
 #define CARTOGRAPHER_ROS_CARTOGRAPHER_ROS_ASSETS_WRITER_H

--- a/cartographer_ros/cartographer_ros/dev/pbstream_trajectories_to_rosbag_main.cc
+++ b/cartographer_ros/cartographer_ros/dev/pbstream_trajectories_to_rosbag_main.cc
@@ -35,12 +35,12 @@ DEFINE_string(parent_frame, "map", "Frame id to use as parent frame.");
 namespace cartographer_ros {
 namespace {
 
-geometry_msgs::TransformStamped ToTransformStamped(
+geometry_msgs::msg::TransformStamped ToTransformStamped(
     int64_t timestamp_uts, const std::string& parent_frame_id,
     const std::string& child_frame_id,
     const cartographer::transform::proto::Rigid3d& parent_T_child) {
   static int64_t seq = 0;
-  geometry_msgs::TransformStamped transform_stamped;
+  geometry_msgs::msg::TransformStamped transform_stamped;
   transform_stamped.header.seq = ++seq;
   transform_stamped.header.frame_id = parent_frame_id;
   transform_stamped.header.stamp = cartographer_ros::ToRos(
@@ -67,7 +67,7 @@ void pbstream_trajectories_to_bag(const std::string& pbstream_filename,
         << " nodes.";
     for (const auto& node : trajectory.node()) {
       tf2_msgs::TFMessage tf_msg;
-      geometry_msgs::TransformStamped transform_stamped = ToTransformStamped(
+      geometry_msgs::msg::TransformStamped transform_stamped = ToTransformStamped(
           node.timestamp(), parent_frame_id, child_frame_id, node.pose());
       tf_msg.transforms.push_back(transform_stamped);
       bag.write(child_frame_id, transform_stamped.header.stamp,

--- a/cartographer_ros/cartographer_ros/map_builder_bridge.cc
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.cc
@@ -17,13 +17,12 @@
 #include "cartographer_ros/map_builder_bridge.h"
 
 #include "absl/memory/memory.h"
-#include "absl/strings/str_cat.h"
 #include "cartographer/io/color.h"
 #include "cartographer/io/proto_stream.h"
 #include "cartographer_ros/msg_conversion.h"
 #include "cartographer_ros/time_conversion.h"
-#include "cartographer_ros_msgs/StatusCode.h"
-#include "cartographer_ros_msgs/StatusResponse.h"
+#include "cartographer_ros_msgs/msg/status_code.hpp"
+#include "cartographer_ros_msgs/msg/status_response.hpp"
 
 namespace cartographer_ros {
 namespace {
@@ -34,8 +33,8 @@ constexpr double kTrajectoryLineStripMarkerScale = 0.07;
 constexpr double kLandmarkMarkerScale = 0.2;
 constexpr double kConstraintMarkerScale = 0.025;
 
-::std_msgs::ColorRGBA ToMessage(const cartographer::io::FloatColor& color) {
-  ::std_msgs::ColorRGBA result;
+::std_msgs::msg::ColorRGBA ToMessage(const cartographer::io::FloatColor& color) {
+  ::std_msgs::msg::ColorRGBA result;
   result.r = color[0];
   result.g = color[1];
   result.b = color[2];
@@ -43,13 +42,14 @@ constexpr double kConstraintMarkerScale = 0.025;
   return result;
 }
 
-visualization_msgs::Marker CreateTrajectoryMarker(const int trajectory_id,
-                                                  const std::string& frame_id) {
-  visualization_msgs::Marker marker;
-  marker.ns = absl::StrCat("Trajectory ", trajectory_id);
+visualization_msgs::msg::Marker CreateTrajectoryMarker(const int trajectory_id,
+                                                  const std::string& frame_id,
+                                                  rclcpp::Time node_time) {
+  visualization_msgs::msg::Marker marker;
+  marker.ns = "Trajectory " + std::to_string(trajectory_id);
   marker.id = 0;
-  marker.type = visualization_msgs::Marker::LINE_STRIP;
-  marker.header.stamp = ::ros::Time::now();
+  marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+  marker.header.stamp = node_time;
   marker.header.frame_id = frame_id;
   marker.color = ToMessage(cartographer::io::GetColor(trajectory_id));
   marker.scale.x = kTrajectoryLineStripMarkerScale;
@@ -70,14 +70,15 @@ int GetLandmarkIndex(
   return it->second;
 }
 
-visualization_msgs::Marker CreateLandmarkMarker(int landmark_index,
+visualization_msgs::msg::Marker CreateLandmarkMarker(int landmark_index,
                                                 const Rigid3d& landmark_pose,
-                                                const std::string& frame_id) {
-  visualization_msgs::Marker marker;
+                                                const std::string& frame_id,
+                                                rclcpp::Time node_time) {
+  visualization_msgs::msg::Marker marker;
   marker.ns = "Landmarks";
   marker.id = landmark_index;
-  marker.type = visualization_msgs::Marker::SPHERE;
-  marker.header.stamp = ::ros::Time::now();
+  marker.type = visualization_msgs::msg::Marker::SPHERE;
+  marker.header.stamp = node_time;
   marker.header.frame_id = frame_id;
   marker.scale.x = kLandmarkMarkerScale;
   marker.scale.y = kLandmarkMarkerScale;
@@ -87,8 +88,8 @@ visualization_msgs::Marker CreateLandmarkMarker(int landmark_index,
   return marker;
 }
 
-void PushAndResetLineMarker(visualization_msgs::Marker* marker,
-                            std::vector<visualization_msgs::Marker>* markers) {
+void PushAndResetLineMarker(visualization_msgs::msg::Marker* marker,
+                            std::vector<visualization_msgs::msg::Marker>* markers) {
   markers->push_back(*marker);
   ++marker->id;
   marker->points.clear();
@@ -168,24 +169,24 @@ bool MapBuilderBridge::SerializeState(const std::string& filename,
 }
 
 void MapBuilderBridge::HandleSubmapQuery(
-    cartographer_ros_msgs::SubmapQuery::Request& request,
-    cartographer_ros_msgs::SubmapQuery::Response& response) {
+    const cartographer_ros_msgs::srv::SubmapQuery::Request::SharedPtr request,
+    cartographer_ros_msgs::srv::SubmapQuery::Response::SharedPtr response) {
   cartographer::mapping::proto::SubmapQuery::Response response_proto;
-  cartographer::mapping::SubmapId submap_id{request.trajectory_id,
-                                            request.submap_index};
+  cartographer::mapping::SubmapId submap_id{request->trajectory_id,
+                                            request->submap_index};
   const std::string error =
       map_builder_->SubmapToProto(submap_id, &response_proto);
   if (!error.empty()) {
     LOG(ERROR) << error;
-    response.status.code = cartographer_ros_msgs::StatusCode::NOT_FOUND;
-    response.status.message = error;
+    response->status.code = cartographer_ros_msgs::msg::StatusCode::NOT_FOUND;
+    response->status.message = error;
     return;
   }
 
-  response.submap_version = response_proto.submap_version();
+  response->submap_version = response_proto.submap_version();
   for (const auto& texture_proto : response_proto.textures()) {
-    response.textures.emplace_back();
-    auto& texture = response.textures.back();
+    response->textures.emplace_back();
+    auto& texture = response->textures.back();
     texture.cells.insert(texture.cells.begin(), texture_proto.cells().begin(),
                          texture_proto.cells().end());
     texture.width = texture_proto.width();
@@ -194,8 +195,8 @@ void MapBuilderBridge::HandleSubmapQuery(
     texture.slice_pose = ToGeometryMsgPose(
         cartographer::transform::ToRigid3(texture_proto.slice_pose()));
   }
-  response.status.message = "Success.";
-  response.status.code = cartographer_ros_msgs::StatusCode::OK;
+  response->status.message = "Success.";
+  response->status.code = cartographer_ros_msgs::msg::StatusCode::OK;
 }
 
 std::map<int, ::cartographer::mapping::PoseGraphInterface::TrajectoryState>
@@ -211,13 +212,13 @@ MapBuilderBridge::GetTrajectoryStates() {
   return trajectory_states;
 }
 
-cartographer_ros_msgs::SubmapList MapBuilderBridge::GetSubmapList() {
-  cartographer_ros_msgs::SubmapList submap_list;
-  submap_list.header.stamp = ::ros::Time::now();
+cartographer_ros_msgs::msg::SubmapList MapBuilderBridge::GetSubmapList(rclcpp::Time node_time) {
+  cartographer_ros_msgs::msg::SubmapList submap_list;
+  submap_list.header.stamp = node_time;
   submap_list.header.frame_id = node_options_.map_frame;
   for (const auto& submap_id_pose :
        map_builder_->pose_graph()->GetAllSubmapPoses()) {
-    cartographer_ros_msgs::SubmapEntry submap_entry;
+    cartographer_ros_msgs::msg::SubmapEntry submap_entry;
     submap_entry.is_frozen = map_builder_->pose_graph()->IsTrajectoryFrozen(
         submap_id_pose.id.trajectory_id);
     submap_entry.trajectory_id = submap_id_pose.id.trajectory_id;
@@ -259,31 +260,33 @@ MapBuilderBridge::GetLocalTrajectoryData() {
 }
 
 void MapBuilderBridge::HandleTrajectoryQuery(
-    cartographer_ros_msgs::TrajectoryQuery::Request& request,
-    cartographer_ros_msgs::TrajectoryQuery::Response& response) {
+    const cartographer_ros_msgs::srv::TrajectoryQuery::Request::SharedPtr request,
+    cartographer_ros_msgs::srv::TrajectoryQuery::Response::SharedPtr response) {
   // This query is safe if the trajectory doesn't exist (returns 0 poses).
   // However, we can filter unwanted states at the higher level in the node.
   const auto node_poses = map_builder_->pose_graph()->GetTrajectoryNodePoses();
   for (const auto& node_id_data :
-       node_poses.trajectory(request.trajectory_id)) {
+       node_poses.trajectory(request->trajectory_id)) {
     if (!node_id_data.data.constant_pose_data.has_value()) {
       continue;
     }
-    geometry_msgs::PoseStamped pose_stamped;
+    geometry_msgs::msg::PoseStamped pose_stamped;
     pose_stamped.header.frame_id = node_options_.map_frame;
     pose_stamped.header.stamp =
         ToRos(node_id_data.data.constant_pose_data.value().time);
     pose_stamped.pose = ToGeometryMsgPose(node_id_data.data.global_pose);
-    response.trajectory.push_back(pose_stamped);
+    response->trajectory.push_back(pose_stamped);
   }
-  response.status.code = cartographer_ros_msgs::StatusCode::OK;
-  response.status.message = absl::StrCat(
-      "Retrieved ", response.trajectory.size(),
-      " trajectory nodes from trajectory ", request.trajectory_id, ".");
+  response->status.code = cartographer_ros_msgs::msg::StatusCode::OK;
+  response->status.message =
+      "Retrieved " + std::to_string(response->trajectory.size()) +
+      " trajectory nodes from trajectory " + std::to_string(request->trajectory_id) + ".";
 }
 
-visualization_msgs::MarkerArray MapBuilderBridge::GetTrajectoryNodeList() {
-  visualization_msgs::MarkerArray trajectory_node_list;
+visualization_msgs::msg::MarkerArray MapBuilderBridge::GetTrajectoryNodeList(
+    rclcpp::Time node_time)
+{
+  visualization_msgs::msg::MarkerArray trajectory_node_list;
   const auto node_poses = map_builder_->pose_graph()->GetTrajectoryNodePoses();
   // Find the last node indices for each trajectory that have either
   // inter-submap or inter-trajectory constraints.
@@ -317,8 +320,8 @@ visualization_msgs::MarkerArray MapBuilderBridge::GetTrajectoryNodeList() {
   }
 
   for (const int trajectory_id : node_poses.trajectory_ids()) {
-    visualization_msgs::Marker marker =
-        CreateTrajectoryMarker(trajectory_id, node_options_.map_frame);
+    visualization_msgs::msg::Marker marker =
+        CreateTrajectoryMarker(trajectory_id, node_options_.map_frame, node_time);
     int last_inter_submap_constrained_node = std::max(
         node_poses.trajectory(trajectory_id).begin()->id.node_index,
         trajectory_to_last_inter_submap_constrained_node.at(trajectory_id));
@@ -342,7 +345,7 @@ visualization_msgs::MarkerArray MapBuilderBridge::GetTrajectoryNodeList() {
         PushAndResetLineMarker(&marker, &trajectory_node_list.markers);
         continue;
       }
-      const ::geometry_msgs::Point node_point =
+      const ::geometry_msgs::msg::Point node_point =
           ToGeometryMsgPoint(node_id_data.data.global_pose.translation());
       marker.points.push_back(node_point);
 
@@ -370,7 +373,7 @@ visualization_msgs::MarkerArray MapBuilderBridge::GetTrajectoryNodeList() {
     if (trajectory_to_highest_marker_id_.count(trajectory_id) == 0) {
       trajectory_to_highest_marker_id_[trajectory_id] = current_last_marker_id;
     } else {
-      marker.action = visualization_msgs::Marker::DELETE;
+      marker.action = visualization_msgs::msg::Marker::DELETE;
       while (static_cast<size_t>(marker.id) <=
              trajectory_to_highest_marker_id_[trajectory_id]) {
         trajectory_node_list.markers.push_back(marker);
@@ -382,31 +385,33 @@ visualization_msgs::MarkerArray MapBuilderBridge::GetTrajectoryNodeList() {
   return trajectory_node_list;
 }
 
-visualization_msgs::MarkerArray MapBuilderBridge::GetLandmarkPosesList() {
-  visualization_msgs::MarkerArray landmark_poses_list;
+visualization_msgs::msg::MarkerArray MapBuilderBridge::GetLandmarkPosesList(
+    rclcpp::Time node_time)
+{
+  visualization_msgs::msg::MarkerArray landmark_poses_list;
   const std::map<std::string, Rigid3d> landmark_poses =
       map_builder_->pose_graph()->GetLandmarkPoses();
   for (const auto& id_to_pose : landmark_poses) {
     landmark_poses_list.markers.push_back(CreateLandmarkMarker(
         GetLandmarkIndex(id_to_pose.first, &landmark_to_index_),
-        id_to_pose.second, node_options_.map_frame));
+        id_to_pose.second, node_options_.map_frame, node_time));
   }
   return landmark_poses_list;
 }
 
-visualization_msgs::MarkerArray MapBuilderBridge::GetConstraintList() {
-  visualization_msgs::MarkerArray constraint_list;
+visualization_msgs::msg::MarkerArray MapBuilderBridge::GetConstraintList(rclcpp::Time node_time) {
+  visualization_msgs::msg::MarkerArray constraint_list;
   int marker_id = 0;
-  visualization_msgs::Marker constraint_intra_marker;
+  visualization_msgs::msg::Marker constraint_intra_marker;
   constraint_intra_marker.id = marker_id++;
   constraint_intra_marker.ns = "Intra constraints";
-  constraint_intra_marker.type = visualization_msgs::Marker::LINE_LIST;
-  constraint_intra_marker.header.stamp = ros::Time::now();
+  constraint_intra_marker.type = visualization_msgs::msg::Marker::LINE_LIST;
+  constraint_intra_marker.header.stamp = node_time;
   constraint_intra_marker.header.frame_id = node_options_.map_frame;
   constraint_intra_marker.scale.x = kConstraintMarkerScale;
   constraint_intra_marker.pose.orientation.w = 1.0;
 
-  visualization_msgs::Marker residual_intra_marker = constraint_intra_marker;
+  visualization_msgs::msg::Marker residual_intra_marker = constraint_intra_marker;
   residual_intra_marker.id = marker_id++;
   residual_intra_marker.ns = "Intra residuals";
   // This and other markers which are less numerous are set to be slightly
@@ -414,27 +419,27 @@ visualization_msgs::MarkerArray MapBuilderBridge::GetConstraintList() {
   // visible.
   residual_intra_marker.pose.position.z = 0.1;
 
-  visualization_msgs::Marker constraint_inter_same_trajectory_marker =
+  visualization_msgs::msg::Marker constraint_inter_same_trajectory_marker =
       constraint_intra_marker;
   constraint_inter_same_trajectory_marker.id = marker_id++;
   constraint_inter_same_trajectory_marker.ns =
       "Inter constraints, same trajectory";
   constraint_inter_same_trajectory_marker.pose.position.z = 0.1;
 
-  visualization_msgs::Marker residual_inter_same_trajectory_marker =
+  visualization_msgs::msg::Marker residual_inter_same_trajectory_marker =
       constraint_intra_marker;
   residual_inter_same_trajectory_marker.id = marker_id++;
   residual_inter_same_trajectory_marker.ns = "Inter residuals, same trajectory";
   residual_inter_same_trajectory_marker.pose.position.z = 0.1;
 
-  visualization_msgs::Marker constraint_inter_diff_trajectory_marker =
+  visualization_msgs::msg::Marker constraint_inter_diff_trajectory_marker =
       constraint_intra_marker;
   constraint_inter_diff_trajectory_marker.id = marker_id++;
   constraint_inter_diff_trajectory_marker.ns =
       "Inter constraints, different trajectories";
   constraint_inter_diff_trajectory_marker.pose.position.z = 0.1;
 
-  visualization_msgs::Marker residual_inter_diff_trajectory_marker =
+  visualization_msgs::msg::Marker residual_inter_diff_trajectory_marker =
       constraint_intra_marker;
   residual_inter_diff_trajectory_marker.id = marker_id++;
   residual_inter_diff_trajectory_marker.ns =
@@ -447,8 +452,8 @@ visualization_msgs::MarkerArray MapBuilderBridge::GetConstraintList() {
   const auto constraints = map_builder_->pose_graph()->constraints();
 
   for (const auto& constraint : constraints) {
-    visualization_msgs::Marker *constraint_marker, *residual_marker;
-    std_msgs::ColorRGBA color_constraint, color_residual;
+    visualization_msgs::msg::Marker *constraint_marker, *residual_marker;
+    std_msgs::msg::ColorRGBA color_constraint, color_residual;
     if (constraint.tag ==
         cartographer::mapping::PoseGraphInterface::Constraint::INTRA_SUBMAP) {
       constraint_marker = &constraint_intra_marker;

--- a/cartographer_ros/cartographer_ros/map_builder_bridge.h
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.h
@@ -31,19 +31,19 @@
 #include "cartographer_ros/sensor_bridge.h"
 #include "cartographer_ros/tf_bridge.h"
 #include "cartographer_ros/trajectory_options.h"
-#include "cartographer_ros_msgs/SubmapEntry.h"
-#include "cartographer_ros_msgs/SubmapList.h"
-#include "cartographer_ros_msgs/SubmapQuery.h"
-#include "cartographer_ros_msgs/TrajectoryQuery.h"
-#include "geometry_msgs/TransformStamped.h"
-#include "nav_msgs/OccupancyGrid.h"
+#include "cartographer_ros_msgs/msg/submap_entry.hpp"
+#include "cartographer_ros_msgs/msg/submap_list.hpp"
+#include "cartographer_ros_msgs/srv/submap_query.hpp"
+#include "cartographer_ros_msgs/srv/trajectory_query.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
 
 // Abseil unfortunately pulls in winnt.h, which #defines DELETE.
-// Clean up to unbreak visualization_msgs::Marker::DELETE.
+// Clean up to unbreak visualization_msgs::msg::Marker::DELETE.
 #ifdef DELETE
 #undef DELETE
 #endif
-#include "visualization_msgs/MarkerArray.h"
+#include "visualization_msgs/msg/marker_array.hpp"
 
 namespace cartographer_ros {
 
@@ -84,21 +84,21 @@ class MapBuilderBridge {
                       const bool include_unfinished_submaps);
 
   void HandleSubmapQuery(
-      cartographer_ros_msgs::SubmapQuery::Request& request,
-      cartographer_ros_msgs::SubmapQuery::Response& response);
+      const cartographer_ros_msgs::srv::SubmapQuery::Request::SharedPtr request,
+      cartographer_ros_msgs::srv::SubmapQuery::Response::SharedPtr response);
   void HandleTrajectoryQuery(
-      cartographer_ros_msgs::TrajectoryQuery::Request& request,
-      cartographer_ros_msgs::TrajectoryQuery::Response& response);
+      const cartographer_ros_msgs::srv::TrajectoryQuery::Request::SharedPtr request,
+      cartographer_ros_msgs::srv::TrajectoryQuery::Response::SharedPtr response);
 
   std::map<int /* trajectory_id */,
            ::cartographer::mapping::PoseGraphInterface::TrajectoryState>
   GetTrajectoryStates();
-  cartographer_ros_msgs::SubmapList GetSubmapList();
+  cartographer_ros_msgs::msg::SubmapList GetSubmapList(rclcpp::Time node_time);
   std::unordered_map<int, LocalTrajectoryData> GetLocalTrajectoryData()
       LOCKS_EXCLUDED(mutex_);
-  visualization_msgs::MarkerArray GetTrajectoryNodeList();
-  visualization_msgs::MarkerArray GetLandmarkPosesList();
-  visualization_msgs::MarkerArray GetConstraintList();
+  visualization_msgs::msg::MarkerArray GetTrajectoryNodeList(rclcpp::Time node_time);
+  visualization_msgs::msg::MarkerArray GetLandmarkPosesList(rclcpp::Time node_time);
+  visualization_msgs::msg::MarkerArray GetConstraintList(rclcpp::Time node_time);
 
   SensorBridge* sensor_bridge(int trajectory_id);
 

--- a/cartographer_ros/cartographer_ros/metrics/family_factory.cc
+++ b/cartographer_ros/cartographer_ros/metrics/family_factory.cc
@@ -53,7 +53,7 @@ FamilyFactory::NewHistogramFamily(const std::string& name,
 }
 
 void FamilyFactory::ReadMetrics(
-    ::cartographer_ros_msgs::ReadMetrics::Response* response) const {
+    cartographer_ros_msgs::srv::ReadMetrics::Response::SharedPtr response) const {
   for (const auto& counter_family : counter_families_) {
     response->metric_families.push_back(counter_family->ToRosMessage());
   }

--- a/cartographer_ros/cartographer_ros/metrics/family_factory.h
+++ b/cartographer_ros/cartographer_ros/metrics/family_factory.h
@@ -25,7 +25,7 @@
 #include "cartographer_ros/metrics/internal/family.h"
 #include "cartographer_ros/metrics/internal/gauge.h"
 #include "cartographer_ros/metrics/internal/histogram.h"
-#include "cartographer_ros_msgs/ReadMetrics.h"
+#include "cartographer_ros_msgs/srv/read_metrics.hpp"
 
 namespace cartographer_ros {
 namespace metrics {
@@ -47,7 +47,7 @@ class FamilyFactory : public ::cartographer::metrics::FamilyFactory {
                          boundaries) override;
 
   void ReadMetrics(
-      ::cartographer_ros_msgs::ReadMetrics::Response* response) const;
+      cartographer_ros_msgs::srv::ReadMetrics::Response::SharedPtr response) const;
 
  private:
   std::vector<std::unique_ptr<CounterFamily>> counter_families_;

--- a/cartographer_ros/cartographer_ros/metrics/internal/counter.h
+++ b/cartographer_ros/cartographer_ros/metrics/internal/counter.h
@@ -19,7 +19,7 @@
 
 #include "cartographer/metrics/counter.h"
 #include "cartographer_ros/metrics/internal/gauge.h"
-#include "cartographer_ros_msgs/Metric.h"
+#include "cartographer_ros_msgs/msg/metric.hpp"
 
 namespace cartographer_ros {
 namespace metrics {
@@ -35,9 +35,9 @@ class Counter : public ::cartographer::metrics::Counter {
 
   double Value() { return gauge_.Value(); }
 
-  cartographer_ros_msgs::Metric ToRosMessage() {
-    cartographer_ros_msgs::Metric msg = gauge_.ToRosMessage();
-    msg.type = cartographer_ros_msgs::Metric::TYPE_COUNTER;
+  cartographer_ros_msgs::msg::Metric ToRosMessage() {
+    cartographer_ros_msgs::msg::Metric msg = gauge_.ToRosMessage();
+    msg.type = cartographer_ros_msgs::msg::Metric::TYPE_COUNTER;
     return msg;
   }
 

--- a/cartographer_ros/cartographer_ros/metrics/internal/family.cc
+++ b/cartographer_ros/cartographer_ros/metrics/internal/family.cc
@@ -33,8 +33,8 @@ Counter* CounterFamily::Add(const std::map<std::string, std::string>& labels) {
   return ptr;
 }
 
-cartographer_ros_msgs::MetricFamily CounterFamily::ToRosMessage() {
-  cartographer_ros_msgs::MetricFamily family_msg;
+cartographer_ros_msgs::msg::MetricFamily CounterFamily::ToRosMessage() {
+  cartographer_ros_msgs::msg::MetricFamily family_msg;
   family_msg.name = name_;
   family_msg.description = description_;
   for (const auto& wrapper : wrappers_) {
@@ -50,8 +50,8 @@ Gauge* GaugeFamily::Add(const std::map<std::string, std::string>& labels) {
   return ptr;
 }
 
-cartographer_ros_msgs::MetricFamily GaugeFamily::ToRosMessage() {
-  cartographer_ros_msgs::MetricFamily family_msg;
+cartographer_ros_msgs::msg::MetricFamily GaugeFamily::ToRosMessage() {
+  cartographer_ros_msgs::msg::MetricFamily family_msg;
   family_msg.name = name_;
   family_msg.description = description_;
   for (const auto& wrapper : wrappers_) {
@@ -68,8 +68,8 @@ Histogram* HistogramFamily::Add(
   return ptr;
 }
 
-cartographer_ros_msgs::MetricFamily HistogramFamily::ToRosMessage() {
-  cartographer_ros_msgs::MetricFamily family_msg;
+cartographer_ros_msgs::msg::MetricFamily HistogramFamily::ToRosMessage() {
+  cartographer_ros_msgs::msg::MetricFamily family_msg;
   family_msg.name = name_;
   family_msg.description = description_;
   for (const auto& wrapper : wrappers_) {

--- a/cartographer_ros/cartographer_ros/metrics/internal/family.h
+++ b/cartographer_ros/cartographer_ros/metrics/internal/family.h
@@ -24,7 +24,7 @@
 #include "cartographer_ros/metrics/internal/counter.h"
 #include "cartographer_ros/metrics/internal/gauge.h"
 #include "cartographer_ros/metrics/internal/histogram.h"
-#include "cartographer_ros_msgs/MetricFamily.h"
+#include "cartographer_ros_msgs/msg/metric_family.hpp"
 
 namespace cartographer_ros {
 namespace metrics {
@@ -34,7 +34,7 @@ class CounterFamily
   CounterFamily(const std::string& name, const std::string& description)
       : name_(name), description_(description) {}
   Counter* Add(const std::map<std::string, std::string>& labels) override;
-  cartographer_ros_msgs::MetricFamily ToRosMessage();
+  cartographer_ros_msgs::msg::MetricFamily ToRosMessage();
 
  private:
   std::string name_;
@@ -49,7 +49,7 @@ class GaugeFamily
       : name_(name), description_(description) {}
   Gauge* Add(const std::map<std::string, std::string>& labels) override;
 
-  cartographer_ros_msgs::MetricFamily ToRosMessage();
+  cartographer_ros_msgs::msg::MetricFamily ToRosMessage();
 
  private:
   std::string name_;
@@ -66,7 +66,7 @@ class HistogramFamily : public ::cartographer::metrics::Family<
 
   Histogram* Add(const std::map<std::string, std::string>& labels) override;
 
-  cartographer_ros_msgs::MetricFamily ToRosMessage();
+  cartographer_ros_msgs::msg::MetricFamily ToRosMessage();
 
  private:
   std::string name_;

--- a/cartographer_ros/cartographer_ros/metrics/internal/gauge.h
+++ b/cartographer_ros/cartographer_ros/metrics/internal/gauge.h
@@ -22,7 +22,7 @@
 
 #include "absl/synchronization/mutex.h"
 #include "cartographer/metrics/gauge.h"
-#include "cartographer_ros_msgs/Metric.h"
+#include "cartographer_ros_msgs/msg/metric.hpp"
 
 namespace cartographer_ros {
 namespace metrics {
@@ -50,11 +50,11 @@ class Gauge : public ::cartographer::metrics::Gauge {
     return value_;
   }
 
-  cartographer_ros_msgs::Metric ToRosMessage() {
-    cartographer_ros_msgs::Metric msg;
-    msg.type = cartographer_ros_msgs::Metric::TYPE_GAUGE;
+  cartographer_ros_msgs::msg::Metric ToRosMessage() {
+    cartographer_ros_msgs::msg::Metric msg;
+    msg.type = cartographer_ros_msgs::msg::Metric::TYPE_GAUGE;
     for (const auto& label : labels_) {
-      cartographer_ros_msgs::MetricLabel label_msg;
+      cartographer_ros_msgs::msg::MetricLabel label_msg;
       label_msg.key = label.first;
       label_msg.value = label.second;
       msg.labels.push_back(label_msg);

--- a/cartographer_ros/cartographer_ros/metrics/internal/histogram.cc
+++ b/cartographer_ros/cartographer_ros/metrics/internal/histogram.cc
@@ -68,17 +68,17 @@ double Histogram::CumulativeCount() {
   return std::accumulate(bucket_counts_.begin(), bucket_counts_.end(), 0.);
 }
 
-cartographer_ros_msgs::Metric Histogram::ToRosMessage() {
-  cartographer_ros_msgs::Metric msg;
-  msg.type = cartographer_ros_msgs::Metric::TYPE_HISTOGRAM;
+cartographer_ros_msgs::msg::Metric Histogram::ToRosMessage() {
+  cartographer_ros_msgs::msg::Metric msg;
+  msg.type = cartographer_ros_msgs::msg::Metric::TYPE_HISTOGRAM;
   for (const auto& label : labels_) {
-    cartographer_ros_msgs::MetricLabel label_msg;
+    cartographer_ros_msgs::msg::MetricLabel label_msg;
     label_msg.key = label.first;
     label_msg.value = label.second;
     msg.labels.push_back(label_msg);
   }
   for (const auto& bucket : CountsByBucket()) {
-    cartographer_ros_msgs::HistogramBucket bucket_msg;
+    cartographer_ros_msgs::msg::HistogramBucket bucket_msg;
     bucket_msg.bucket_boundary = bucket.first;
     bucket_msg.count = bucket.second;
     msg.counts_by_bucket.push_back(bucket_msg);

--- a/cartographer_ros/cartographer_ros/metrics/internal/histogram.h
+++ b/cartographer_ros/cartographer_ros/metrics/internal/histogram.h
@@ -22,7 +22,7 @@
 
 #include "absl/synchronization/mutex.h"
 #include "cartographer/metrics/histogram.h"
-#include "cartographer_ros_msgs/Metric.h"
+#include "cartographer_ros_msgs/msg/metric.hpp"
 
 namespace cartographer_ros {
 namespace metrics {
@@ -44,7 +44,7 @@ class Histogram : public ::cartographer::metrics::Histogram {
 
   double CumulativeCount();
 
-  cartographer_ros_msgs::Metric ToRosMessage();
+  cartographer_ros_msgs::msg::Metric ToRosMessage();
 
  private:
   absl::Mutex mutex_;

--- a/cartographer_ros/cartographer_ros/msg_conversion.h
+++ b/cartographer_ros/cartographer_ros/msg_conversion.h
@@ -22,56 +22,57 @@
 #include "cartographer/sensor/landmark_data.h"
 #include "cartographer/sensor/point_cloud.h"
 #include "cartographer/transform/rigid_transform.h"
-#include "cartographer_ros_msgs/LandmarkList.h"
-#include "geometry_msgs/Pose.h"
-#include "geometry_msgs/Transform.h"
-#include "geometry_msgs/TransformStamped.h"
-#include "nav_msgs/OccupancyGrid.h"
-#include "sensor_msgs/Imu.h"
-#include "sensor_msgs/LaserScan.h"
-#include "sensor_msgs/MultiEchoLaserScan.h"
-#include "sensor_msgs/PointCloud2.h"
+#include "cartographer_ros_msgs/msg/landmark_list.hpp"
+#include "geometry_msgs/msg/pose.hpp"
+#include "geometry_msgs/msg/point.hpp"
+#include "geometry_msgs/msg/transform.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+#include "sensor_msgs/msg/multi_echo_laser_scan.hpp"
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace cartographer_ros {
 
-sensor_msgs::PointCloud2 ToPointCloud2Message(
+sensor_msgs::msg::PointCloud2 ToPointCloud2Message(
     int64_t timestamp, const std::string& frame_id,
     const ::cartographer::sensor::TimedPointCloud& point_cloud);
 
-geometry_msgs::Transform ToGeometryMsgTransform(
+geometry_msgs::msg::Transform ToGeometryMsgTransform(
     const ::cartographer::transform::Rigid3d& rigid3d);
 
-geometry_msgs::Pose ToGeometryMsgPose(
+geometry_msgs::msg::Pose ToGeometryMsgPose(
     const ::cartographer::transform::Rigid3d& rigid3d);
 
-geometry_msgs::Point ToGeometryMsgPoint(const Eigen::Vector3d& vector3d);
+geometry_msgs::msg::Point ToGeometryMsgPoint(const Eigen::Vector3d& vector3d);
 
 // Converts ROS message to point cloud. Returns the time when the last point
 // was acquired (different from the ROS timestamp). Timing of points is given in
 // the fourth component of each point relative to `Time`.
 std::tuple<::cartographer::sensor::PointCloudWithIntensities,
            ::cartographer::common::Time>
-ToPointCloudWithIntensities(const sensor_msgs::LaserScan& msg);
+ToPointCloudWithIntensities(const sensor_msgs::msg::LaserScan& msg);
 
 std::tuple<::cartographer::sensor::PointCloudWithIntensities,
            ::cartographer::common::Time>
-ToPointCloudWithIntensities(const sensor_msgs::MultiEchoLaserScan& msg);
+ToPointCloudWithIntensities(const sensor_msgs::msg::MultiEchoLaserScan& msg);
 
 std::tuple<::cartographer::sensor::PointCloudWithIntensities,
            ::cartographer::common::Time>
-ToPointCloudWithIntensities(const sensor_msgs::PointCloud2& msg);
+ToPointCloudWithIntensities(const sensor_msgs::msg::PointCloud2& msg);
 
 ::cartographer::sensor::LandmarkData ToLandmarkData(
-    const cartographer_ros_msgs::LandmarkList& landmark_list);
+    const cartographer_ros_msgs::msg::LandmarkList& landmark_list);
 
 ::cartographer::transform::Rigid3d ToRigid3d(
-    const geometry_msgs::TransformStamped& transform);
+    const geometry_msgs::msg::TransformStamped& transform);
 
-::cartographer::transform::Rigid3d ToRigid3d(const geometry_msgs::Pose& pose);
+::cartographer::transform::Rigid3d ToRigid3d(const geometry_msgs::msg::Pose& pose);
 
-Eigen::Vector3d ToEigen(const geometry_msgs::Vector3& vector3);
+Eigen::Vector3d ToEigen(const geometry_msgs::msg::Vector3& vector3);
 
-Eigen::Quaterniond ToEigen(const geometry_msgs::Quaternion& quaternion);
+Eigen::Quaterniond ToEigen(const geometry_msgs::msg::Quaternion& quaternion);
 
 // Converts from WGS84 (latitude, longitude, altitude) to ECEF.
 Eigen::Vector3d LatLongAltToEcef(double latitude, double longitude,
@@ -84,10 +85,10 @@ cartographer::transform::Rigid3d ComputeLocalFrameFromLatLong(double latitude,
 
 // Points to an occupancy grid message at a specific resolution from painted
 // submap slices obtained via ::cartographer::io::PaintSubmapSlices(...).
-std::unique_ptr<nav_msgs::OccupancyGrid> CreateOccupancyGridMsg(
+std::unique_ptr<nav_msgs::msg::OccupancyGrid> CreateOccupancyGridMsg(
     const cartographer::io::PaintSubmapSlicesResult& painted_slices,
     const double resolution, const std::string& frame_id,
-    const ros::Time& time);
+    const rclcpp::Time& time);
 
 }  // namespace cartographer_ros
 

--- a/cartographer_ros/cartographer_ros/msg_conversion_test.cc
+++ b/cartographer_ros/cartographer_ros/msg_conversion_test.cc
@@ -38,7 +38,7 @@ using ::testing::Field;
 constexpr double kEps = 1e-6;
 
 TEST(MsgConversion, LaserScanToPointCloud) {
-  sensor_msgs::LaserScan laser_scan;
+  sensor_msgs::msg::LaserScan laser_scan;
   for (int i = 0; i < 8; ++i) {
     laser_scan.ranges.push_back(1.f);
   }
@@ -73,7 +73,7 @@ TEST(MsgConversion, LaserScanToPointCloud) {
 }
 
 TEST(MsgConversion, LaserScanToPointCloudWithInfinityAndNaN) {
-  sensor_msgs::LaserScan laser_scan;
+  sensor_msgs::msg::LaserScan laser_scan;
   laser_scan.ranges.push_back(1.f);
   laser_scan.ranges.push_back(std::numeric_limits<float>::infinity());
   laser_scan.ranges.push_back(2.f);
@@ -110,10 +110,10 @@ TEST(MsgConversion, LaserScanToPointCloudWithInfinityAndNaN) {
 }
 
 TEST(MsgConversion, LandmarkListToLandmarkData) {
-  cartographer_ros_msgs::LandmarkList message;
+  cartographer_ros_msgs::msg::LandmarkList message;
   message.header.stamp.fromSec(10);
 
-  cartographer_ros_msgs::LandmarkEntry landmark_0;
+  cartographer_ros_msgs::msg::LandmarkEntry landmark_0;
   landmark_0.id = "landmark_0";
   landmark_0.tracking_from_landmark_transform.position.x = 1.0;
   landmark_0.tracking_from_landmark_transform.position.y = 2.0;

--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -22,7 +22,6 @@
 
 #include "Eigen/Core"
 #include "absl/memory/memory.h"
-#include "absl/strings/str_cat.h"
 #include "cartographer/common/configuration_file_resolver.h"
 #include "cartographer/common/lua_parameter_dictionary.h"
 #include "cartographer/common/port.h"
@@ -38,15 +37,15 @@
 #include "cartographer_ros/sensor_bridge.h"
 #include "cartographer_ros/tf_bridge.h"
 #include "cartographer_ros/time_conversion.h"
-#include "cartographer_ros_msgs/StatusCode.h"
-#include "cartographer_ros_msgs/StatusResponse.h"
-#include "geometry_msgs/PoseStamped.h"
+#include "cartographer_ros_msgs/msg/status_code.hpp"
+#include "cartographer_ros_msgs/msg/status_response.hpp"
+#include "geometry_msgs/msg/point_stamped.hpp"
 #include "glog/logging.h"
-#include "nav_msgs/Odometry.h"
-#include "ros/serialization.h"
-#include "sensor_msgs/PointCloud2.h"
+#include "nav_msgs/msg/odometry.hpp"
+//#include "ros/serialization.h"
+#include "sensor_msgs/msg/point_cloud2.hpp"
 #include "tf2_eigen/tf2_eigen.h"
-#include "visualization_msgs/MarkerArray.h"
+#include "visualization_msgs/msg/marker_array.hpp"
 
 namespace cartographer_ros {
 
@@ -60,18 +59,16 @@ namespace {
 // Subscribes to the 'topic' for 'trajectory_id' using the 'node_handle' and
 // calls 'handler' on the 'node' to handle messages. Returns the subscriber.
 template <typename MessageType>
-::ros::Subscriber SubscribeWithHandler(
+::rclcpp::SubscriptionBase::SharedPtr SubscribeWithHandler(
     void (Node::*handler)(int, const std::string&,
-                          const typename MessageType::ConstPtr&),
+                          const typename MessageType::ConstSharedPtr&),
     const int trajectory_id, const std::string& topic,
-    ::ros::NodeHandle* const node_handle, Node* const node) {
-  return node_handle->subscribe<MessageType>(
-      topic, kInfiniteSubscriberQueueSize,
-      boost::function<void(const typename MessageType::ConstPtr&)>(
-          [node, handler, trajectory_id,
-           topic](const typename MessageType::ConstPtr& msg) {
+    ::rclcpp::Node::SharedPtr node_handle, Node* const node) {
+  return node_handle->create_subscription<MessageType>(
+      topic, rclcpp::SensorDataQoS(),
+      [node, handler, trajectory_id, topic](const typename MessageType::ConstSharedPtr msg) {
             (node->*handler)(trajectory_id, topic, msg);
-          }));
+          });
 }
 
 std::string TrajectoryStateToString(const TrajectoryState trajectory_state) {
@@ -93,9 +90,15 @@ std::string TrajectoryStateToString(const TrajectoryState trajectory_state) {
 Node::Node(
     const NodeOptions& node_options,
     std::unique_ptr<cartographer::mapping::MapBuilderInterface> map_builder,
-    tf2_ros::Buffer* const tf_buffer, const bool collect_metrics)
-    : node_options_(node_options),
-      map_builder_bridge_(node_options_, std::move(map_builder), tf_buffer) {
+    std::shared_ptr<tf2_ros::Buffer> tf_buffer,
+    rclcpp::Node::SharedPtr node,
+    const bool collect_metrics)
+    : node_options_(node_options)
+{
+  node_ = node;
+  tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(node_) ;
+  map_builder_bridge_.reset(new cartographer_ros::MapBuilderBridge(node_options_, std::move(map_builder), tf_buffer.get()));
+
   absl::MutexLock lock(&mutex_);
   if (collect_metrics) {
     metrics_registry_ = absl::make_unique<metrics::FamilyFactory>();
@@ -103,92 +106,116 @@ Node::Node(
   }
 
   submap_list_publisher_ =
-      node_handle_.advertise<::cartographer_ros_msgs::SubmapList>(
-          kSubmapListTopic, kLatestOnlyPublisherQueueSize);
+      node_->create_publisher<::cartographer_ros_msgs::msg::SubmapList>(
+          kSubmapListTopic, 10);
   trajectory_node_list_publisher_ =
-      node_handle_.advertise<::visualization_msgs::MarkerArray>(
-          kTrajectoryNodeListTopic, kLatestOnlyPublisherQueueSize);
+      node_->create_publisher<::visualization_msgs::msg::MarkerArray>(
+          kTrajectoryNodeListTopic, 10);
   landmark_poses_list_publisher_ =
-      node_handle_.advertise<::visualization_msgs::MarkerArray>(
-          kLandmarkPosesListTopic, kLatestOnlyPublisherQueueSize);
+      node_->create_publisher<::visualization_msgs::msg::MarkerArray>(
+          kLandmarkPosesListTopic, 10);
   constraint_list_publisher_ =
-      node_handle_.advertise<::visualization_msgs::MarkerArray>(
-          kConstraintListTopic, kLatestOnlyPublisherQueueSize);
+      node_->create_publisher<::visualization_msgs::msg::MarkerArray>(
+          kConstraintListTopic, 10);
   if (node_options_.publish_tracked_pose) {
     tracked_pose_publisher_ =
-        node_handle_.advertise<::geometry_msgs::PoseStamped>(
-            kTrackedPoseTopic, kLatestOnlyPublisherQueueSize);
+        node_->create_publisher<::geometry_msgs::msg::PoseStamped>(
+            kTrackedPoseTopic, 10);
   }
-  service_servers_.push_back(node_handle_.advertiseService(
-      kSubmapQueryServiceName, &Node::HandleSubmapQuery, this));
-  service_servers_.push_back(node_handle_.advertiseService(
-      kTrajectoryQueryServiceName, &Node::HandleTrajectoryQuery, this));
-  service_servers_.push_back(node_handle_.advertiseService(
-      kStartTrajectoryServiceName, &Node::HandleStartTrajectory, this));
-  service_servers_.push_back(node_handle_.advertiseService(
-      kFinishTrajectoryServiceName, &Node::HandleFinishTrajectory, this));
-  service_servers_.push_back(node_handle_.advertiseService(
-      kWriteStateServiceName, &Node::HandleWriteState, this));
-  service_servers_.push_back(node_handle_.advertiseService(
-      kGetTrajectoryStatesServiceName, &Node::HandleGetTrajectoryStates, this));
-  service_servers_.push_back(node_handle_.advertiseService(
-      kReadMetricsServiceName, &Node::HandleReadMetrics, this));
 
   scan_matched_point_cloud_publisher_ =
-      node_handle_.advertise<sensor_msgs::PointCloud2>(
-          kScanMatchedPointCloudTopic, kLatestOnlyPublisherQueueSize);
+      node_->create_publisher<sensor_msgs::msg::PointCloud2>(
+        kScanMatchedPointCloudTopic, 10);
 
-  wall_timers_.push_back(node_handle_.createWallTimer(
-      ::ros::WallDuration(node_options_.submap_publish_period_sec),
-      &Node::PublishSubmapList, this));
+  submap_query_server_ = node_->create_service<cartographer_ros_msgs::srv::SubmapQuery>(
+      kSubmapQueryServiceName,
+      std::bind(
+          &Node::handleSubmapQuery, this, std::placeholders::_1, std::placeholders::_2));
+  trajectory_query_server = node_->create_service<cartographer_ros_msgs::srv::TrajectoryQuery>(
+      kTrajectoryQueryServiceName,
+      std::bind(
+          &Node::handleTrajectoryQuery, this, std::placeholders::_1, std::placeholders::_2));
+  start_trajectory_server_ = node_->create_service<cartographer_ros_msgs::srv::StartTrajectory>(
+      kStartTrajectoryServiceName,
+      std::bind(
+          &Node::handleStartTrajectory, this, std::placeholders::_1, std::placeholders::_2));
+  finish_trajectory_server_ = node_->create_service<cartographer_ros_msgs::srv::FinishTrajectory>(
+      kFinishTrajectoryServiceName,
+      std::bind(
+          &Node::handleFinishTrajectory, this, std::placeholders::_1, std::placeholders::_2));
+  write_state_server_ = node_->create_service<cartographer_ros_msgs::srv::WriteState>(
+      kWriteStateServiceName,
+      std::bind(
+          &Node::handleWriteState, this, std::placeholders::_1, std::placeholders::_2));
+  get_trajectory_states_server_ = node_->create_service<cartographer_ros_msgs::srv::GetTrajectoryStates>(
+      kGetTrajectoryStatesServiceName,
+      std::bind(
+          &Node::handleGetTrajectoryStates, this, std::placeholders::_1, std::placeholders::_2));
+  read_metrics_server_ = node_->create_service<cartographer_ros_msgs::srv::ReadMetrics>(
+      kReadMetricsServiceName,
+      std::bind(
+          &Node::handleReadMetrics, this, std::placeholders::_1, std::placeholders::_2));
+
+
+  submap_list_timer_ = node_->create_wall_timer(
+    std::chrono::milliseconds(int(node_options_.submap_publish_period_sec * 1000)),
+    [this]() {
+      PublishSubmapList();
+    });
   if (node_options_.pose_publish_period_sec > 0) {
-    publish_local_trajectory_data_timer_ = node_handle_.createTimer(
-        ::ros::Duration(node_options_.pose_publish_period_sec),
-        &Node::PublishLocalTrajectoryData, this);
+    local_trajectory_data_timer_ = node_->create_wall_timer(
+      std::chrono::milliseconds(int(node_options_.pose_publish_period_sec * 1000)),
+      [this]() {
+        PublishLocalTrajectoryData();
+      });
   }
-  wall_timers_.push_back(node_handle_.createWallTimer(
-      ::ros::WallDuration(node_options_.trajectory_publish_period_sec),
-      &Node::PublishTrajectoryNodeList, this));
-  wall_timers_.push_back(node_handle_.createWallTimer(
-      ::ros::WallDuration(node_options_.trajectory_publish_period_sec),
-      &Node::PublishLandmarkPosesList, this));
-  wall_timers_.push_back(node_handle_.createWallTimer(
-      ::ros::WallDuration(kConstraintPublishPeriodSec),
-      &Node::PublishConstraintList, this));
+  trajectory_node_list_timer_ = node_->create_wall_timer(
+    std::chrono::milliseconds(int(node_options_.trajectory_publish_period_sec * 1000)),
+    [this]() {
+      PublishTrajectoryNodeList();
+    });
+  landmark_pose_list_timer_ = node_->create_wall_timer(
+    std::chrono::milliseconds(int(node_options_.trajectory_publish_period_sec * 1000)),
+    [this]() {
+      PublishLandmarkPosesList();
+    });
+  constrain_list_timer_ = node_->create_wall_timer(
+    std::chrono::milliseconds(int(kConstraintPublishPeriodSec * 1000)),
+    [this]() {
+      PublishConstraintList();
+    });
 }
 
 Node::~Node() { FinishAllTrajectories(); }
 
-::ros::NodeHandle* Node::node_handle() { return &node_handle_; }
-
-bool Node::HandleSubmapQuery(
-    ::cartographer_ros_msgs::SubmapQuery::Request& request,
-    ::cartographer_ros_msgs::SubmapQuery::Response& response) {
+bool Node::handleSubmapQuery(
+    const cartographer_ros_msgs::srv::SubmapQuery::Request::SharedPtr request,
+    cartographer_ros_msgs::srv::SubmapQuery::Response::SharedPtr response) {
   absl::MutexLock lock(&mutex_);
-  map_builder_bridge_.HandleSubmapQuery(request, response);
+  map_builder_bridge_->HandleSubmapQuery(request, response);
   return true;
 }
 
-bool Node::HandleTrajectoryQuery(
-    ::cartographer_ros_msgs::TrajectoryQuery::Request& request,
-    ::cartographer_ros_msgs::TrajectoryQuery::Response& response) {
+bool Node::handleTrajectoryQuery(
+    const cartographer_ros_msgs::srv::TrajectoryQuery::Request::SharedPtr request,
+    cartographer_ros_msgs::srv::TrajectoryQuery::Response::SharedPtr response) {
   absl::MutexLock lock(&mutex_);
-  response.status = TrajectoryStateToStatus(
-      request.trajectory_id,
+  response->status = TrajectoryStateToStatus(
+      request->trajectory_id,
       {TrajectoryState::ACTIVE, TrajectoryState::FINISHED,
        TrajectoryState::FROZEN} /* valid states */);
-  if (response.status.code != cartographer_ros_msgs::StatusCode::OK) {
+  if (response->status.code != cartographer_ros_msgs::msg::StatusCode::OK) {
     LOG(ERROR) << "Can't query trajectory from pose graph: "
-               << response.status.message;
+               << response->status.message;
     return true;
   }
-  map_builder_bridge_.HandleTrajectoryQuery(request, response);
+  map_builder_bridge_->HandleTrajectoryQuery(request, response);
   return true;
 }
 
-void Node::PublishSubmapList(const ::ros::WallTimerEvent& unused_timer_event) {
+void Node::PublishSubmapList() {
   absl::MutexLock lock(&mutex_);
-  submap_list_publisher_.publish(map_builder_bridge_.GetSubmapList());
+  submap_list_publisher_->publish(map_builder_bridge_->GetSubmapList(node_->now()));
 }
 
 void Node::AddExtrapolator(const int trajectory_id,
@@ -219,9 +246,9 @@ void Node::AddSensorSamplers(const int trajectory_id,
           options.landmarks_sampling_ratio));
 }
 
-void Node::PublishLocalTrajectoryData(const ::ros::TimerEvent& timer_event) {
+void Node::PublishLocalTrajectoryData() {
   absl::MutexLock lock(&mutex_);
-  for (const auto& entry : map_builder_bridge_.GetLocalTrajectoryData()) {
+  for (const auto& entry : map_builder_bridge_->GetLocalTrajectoryData()) {
     const auto& trajectory_data = entry.second;
 
     auto& extrapolator = extrapolators_.at(entry.first);
@@ -229,7 +256,7 @@ void Node::PublishLocalTrajectoryData(const ::ros::TimerEvent& timer_event) {
     // frequency, and republishing it would be computationally wasteful.
     if (trajectory_data.local_slam_data->time !=
         extrapolator.GetLastPoseTime()) {
-      if (scan_matched_point_cloud_publisher_.getNumSubscribers() > 0) {
+      if (scan_matched_point_cloud_publisher_->get_subscription_count() > 0) {
         // TODO(gaschler): Consider using other message without time
         // information.
         carto::sensor::TimedPointCloud point_cloud;
@@ -240,7 +267,7 @@ void Node::PublishLocalTrajectoryData(const ::ros::TimerEvent& timer_event) {
           point_cloud.push_back(cartographer::sensor::ToTimedRangefinderPoint(
               point, 0.f /* time */));
         }
-        scan_matched_point_cloud_publisher_.publish(ToPointCloud2Message(
+        scan_matched_point_cloud_publisher_->publish(ToPointCloud2Message(
             carto::common::ToUniversal(trajectory_data.local_slam_data->time),
             node_options_.map_frame,
             carto::sensor::TransformTimedPointCloud(
@@ -250,13 +277,13 @@ void Node::PublishLocalTrajectoryData(const ::ros::TimerEvent& timer_event) {
                            trajectory_data.local_slam_data->local_pose);
     }
 
-    geometry_msgs::TransformStamped stamped_transform;
+    geometry_msgs::msg::TransformStamped stamped_transform;
     // If we do not publish a new point cloud, we still allow time of the
     // published poses to advance. If we already know a newer pose, we use its
     // time instead. Since tf knows how to interpolate, providing newer
     // information is better.
     const ::cartographer::common::Time now = std::max(
-        FromRos(ros::Time::now()), extrapolator.GetLastExtrapolatedTime());
+        FromRos(node_->now()), extrapolator.GetLastExtrapolatedTime());
     stamped_transform.header.stamp =
         node_options_.use_pose_extrapolator
             ? ToRos(now)
@@ -288,7 +315,7 @@ void Node::PublishLocalTrajectoryData(const ::ros::TimerEvent& timer_event) {
     if (trajectory_data.published_to_tracking != nullptr) {
       if (node_options_.publish_to_tf) {
         if (trajectory_data.trajectory_options.provide_odom_frame) {
-          std::vector<geometry_msgs::TransformStamped> stamped_transforms;
+          std::vector<geometry_msgs::msg::TransformStamped> stamped_transforms;
 
           stamped_transform.header.frame_id = node_options_.map_frame;
           stamped_transform.child_frame_id =
@@ -305,50 +332,47 @@ void Node::PublishLocalTrajectoryData(const ::ros::TimerEvent& timer_event) {
               tracking_to_local * (*trajectory_data.published_to_tracking));
           stamped_transforms.push_back(stamped_transform);
 
-          tf_broadcaster_.sendTransform(stamped_transforms);
+          tf_broadcaster_->sendTransform(stamped_transforms);
         } else {
           stamped_transform.header.frame_id = node_options_.map_frame;
           stamped_transform.child_frame_id =
               trajectory_data.trajectory_options.published_frame;
           stamped_transform.transform = ToGeometryMsgTransform(
               tracking_to_map * (*trajectory_data.published_to_tracking));
-          tf_broadcaster_.sendTransform(stamped_transform);
+          tf_broadcaster_->sendTransform(stamped_transform);
         }
       }
       if (node_options_.publish_tracked_pose) {
-        ::geometry_msgs::PoseStamped pose_msg;
+        ::geometry_msgs::msg::PoseStamped pose_msg;
         pose_msg.header.frame_id = node_options_.map_frame;
         pose_msg.header.stamp = stamped_transform.header.stamp;
         pose_msg.pose = ToGeometryMsgPose(tracking_to_map);
-        tracked_pose_publisher_.publish(pose_msg);
+        tracked_pose_publisher_->publish(pose_msg);
       }
     }
   }
 }
 
-void Node::PublishTrajectoryNodeList(
-    const ::ros::WallTimerEvent& unused_timer_event) {
-  if (trajectory_node_list_publisher_.getNumSubscribers() > 0) {
+void Node::PublishTrajectoryNodeList() {
+  if (trajectory_node_list_publisher_->get_subscription_count() > 0) {
     absl::MutexLock lock(&mutex_);
-    trajectory_node_list_publisher_.publish(
-        map_builder_bridge_.GetTrajectoryNodeList());
+    trajectory_node_list_publisher_->publish(
+        map_builder_bridge_->GetTrajectoryNodeList(node_->now()));
   }
 }
 
-void Node::PublishLandmarkPosesList(
-    const ::ros::WallTimerEvent& unused_timer_event) {
-  if (landmark_poses_list_publisher_.getNumSubscribers() > 0) {
+void Node::PublishLandmarkPosesList() {
+  if (landmark_poses_list_publisher_->get_subscription_count() > 0) {
     absl::MutexLock lock(&mutex_);
-    landmark_poses_list_publisher_.publish(
-        map_builder_bridge_.GetLandmarkPosesList());
+    landmark_poses_list_publisher_->publish(
+        map_builder_bridge_->GetLandmarkPosesList(node_->now()));
   }
 }
 
-void Node::PublishConstraintList(
-    const ::ros::WallTimerEvent& unused_timer_event) {
-  if (constraint_list_publisher_.getNumSubscribers() > 0) {
+void Node::PublishConstraintList() {
+  if (constraint_list_publisher_->get_subscription_count() > 0) {
     absl::MutexLock lock(&mutex_);
-    constraint_list_publisher_.publish(map_builder_bridge_.GetConstraintList());
+    constraint_list_publisher_->publish(map_builder_bridge_->GetConstraintList(node_->now()));
   }
 }
 
@@ -398,13 +422,15 @@ int Node::AddTrajectory(const TrajectoryOptions& options) {
   const std::set<cartographer::mapping::TrajectoryBuilderInterface::SensorId>
       expected_sensor_ids = ComputeExpectedSensorIds(options);
   const int trajectory_id =
-      map_builder_bridge_.AddTrajectory(expected_sensor_ids, options);
+      map_builder_bridge_->AddTrajectory(expected_sensor_ids, options);
   AddExtrapolator(trajectory_id, options);
   AddSensorSamplers(trajectory_id, options);
   LaunchSubscribers(options, trajectory_id);
-  wall_timers_.push_back(node_handle_.createWallTimer(
-      ::ros::WallDuration(kTopicMismatchCheckDelaySec),
-      &Node::MaybeWarnAboutTopicMismatch, this, /*oneshot=*/true));
+  maybe_warn_about_topic_mismatch_timer_ = node_->create_wall_timer(
+    std::chrono::milliseconds(int(kTopicMismatchCheckDelaySec * 1000)),
+    [this]() {
+      MaybeWarnAboutTopicMismatch();
+    });
   for (const auto& sensor_id : expected_sensor_ids) {
     subscribed_topics_.insert(sensor_id.id);
   }
@@ -416,25 +442,22 @@ void Node::LaunchSubscribers(const TrajectoryOptions& options,
   for (const std::string& topic :
        ComputeRepeatedTopicNames(kLaserScanTopic, options.num_laser_scans)) {
     subscribers_[trajectory_id].push_back(
-        {SubscribeWithHandler<sensor_msgs::LaserScan>(
-             &Node::HandleLaserScanMessage, trajectory_id, topic, &node_handle_,
-             this),
+        {SubscribeWithHandler<sensor_msgs::msg::LaserScan>(
+             &Node::HandleLaserScanMessage, trajectory_id, topic, node_, this),
          topic});
   }
   for (const std::string& topic : ComputeRepeatedTopicNames(
            kMultiEchoLaserScanTopic, options.num_multi_echo_laser_scans)) {
     subscribers_[trajectory_id].push_back(
-        {SubscribeWithHandler<sensor_msgs::MultiEchoLaserScan>(
-             &Node::HandleMultiEchoLaserScanMessage, trajectory_id, topic,
-             &node_handle_, this),
+        {SubscribeWithHandler<sensor_msgs::msg::MultiEchoLaserScan>(
+             &Node::HandleMultiEchoLaserScanMessage, trajectory_id, topic, node_, this),
          topic});
   }
   for (const std::string& topic :
        ComputeRepeatedTopicNames(kPointCloud2Topic, options.num_point_clouds)) {
     subscribers_[trajectory_id].push_back(
-        {SubscribeWithHandler<sensor_msgs::PointCloud2>(
-             &Node::HandlePointCloud2Message, trajectory_id, topic,
-             &node_handle_, this),
+        {SubscribeWithHandler<sensor_msgs::msg::PointCloud2>(
+             &Node::HandlePointCloud2Message, trajectory_id, topic, node_, this),
          topic});
   }
 
@@ -445,31 +468,31 @@ void Node::LaunchSubscribers(const TrajectoryOptions& options,
        options.trajectory_builder_options.trajectory_builder_2d_options()
            .use_imu_data())) {
     subscribers_[trajectory_id].push_back(
-        {SubscribeWithHandler<sensor_msgs::Imu>(&Node::HandleImuMessage,
+        {SubscribeWithHandler<sensor_msgs::msg::Imu>(&Node::HandleImuMessage,
                                                 trajectory_id, kImuTopic,
-                                                &node_handle_, this),
+                                                node_, this),
          kImuTopic});
   }
 
   if (options.use_odometry) {
     subscribers_[trajectory_id].push_back(
-        {SubscribeWithHandler<nav_msgs::Odometry>(&Node::HandleOdometryMessage,
+        {SubscribeWithHandler<nav_msgs::msg::Odometry>(&Node::HandleOdometryMessage,
                                                   trajectory_id, kOdometryTopic,
-                                                  &node_handle_, this),
+                                                  node_, this),
          kOdometryTopic});
   }
   if (options.use_nav_sat) {
     subscribers_[trajectory_id].push_back(
-        {SubscribeWithHandler<sensor_msgs::NavSatFix>(
+        {SubscribeWithHandler<sensor_msgs::msg::NavSatFix>(
              &Node::HandleNavSatFixMessage, trajectory_id, kNavSatFixTopic,
-             &node_handle_, this),
+             node_, this),
          kNavSatFixTopic});
   }
   if (options.use_landmarks) {
     subscribers_[trajectory_id].push_back(
-        {SubscribeWithHandler<cartographer_ros_msgs::LandmarkList>(
+        {SubscribeWithHandler<cartographer_ros_msgs::msg::LandmarkList>(
              &Node::HandleLandmarkMessage, trajectory_id, kLandmarkTopic,
-             &node_handle_, this),
+             node_, this),
          kLandmarkTopic});
   }
 }
@@ -497,36 +520,34 @@ bool Node::ValidateTopicNames(const TrajectoryOptions& options) {
   return true;
 }
 
-cartographer_ros_msgs::StatusResponse Node::TrajectoryStateToStatus(
+cartographer_ros_msgs::msg::StatusResponse Node::TrajectoryStateToStatus(
     const int trajectory_id, const std::set<TrajectoryState>& valid_states) {
-  const auto trajectory_states = map_builder_bridge_.GetTrajectoryStates();
-  cartographer_ros_msgs::StatusResponse status_response;
+  const auto trajectory_states = map_builder_bridge_->GetTrajectoryStates();
+  cartographer_ros_msgs::msg::StatusResponse status_response;
 
   const auto it = trajectory_states.find(trajectory_id);
   if (it == trajectory_states.end()) {
-    status_response.message =
-        absl::StrCat("Trajectory ", trajectory_id, " doesn't exist.");
-    status_response.code = cartographer_ros_msgs::StatusCode::NOT_FOUND;
+    status_response.message = "Trajectory " + std::to_string(trajectory_id) + " doesn't exist.";
+    status_response.code = cartographer_ros_msgs::msg::StatusCode::NOT_FOUND;
     return status_response;
   }
 
-  status_response.message =
-      absl::StrCat("Trajectory ", trajectory_id, " is in '",
-                   TrajectoryStateToString(it->second), "' state.");
+  status_response.message = "Trajectory " + std::to_string(trajectory_id) + " is in '" +
+    TrajectoryStateToString(it->second) + "' state.";
   status_response.code =
       valid_states.count(it->second)
-          ? cartographer_ros_msgs::StatusCode::OK
-          : cartographer_ros_msgs::StatusCode::INVALID_ARGUMENT;
+          ? cartographer_ros_msgs::msg::StatusCode::OK
+          : cartographer_ros_msgs::msg::StatusCode::INVALID_ARGUMENT;
   return status_response;
 }
 
-cartographer_ros_msgs::StatusResponse Node::FinishTrajectoryUnderLock(
+cartographer_ros_msgs::msg::StatusResponse Node::FinishTrajectoryUnderLock(
     const int trajectory_id) {
-  cartographer_ros_msgs::StatusResponse status_response;
+  cartographer_ros_msgs::msg::StatusResponse status_response;
   if (trajectories_scheduled_for_finish_.count(trajectory_id)) {
-    status_response.message = absl::StrCat("Trajectory ", trajectory_id,
-                                           " already pending to finish.");
-    status_response.code = cartographer_ros_msgs::StatusCode::OK;
+    status_response.message =
+        "Trajectory " + std::to_string(trajectory_id) + " already pending to finish.";
+    status_response.code = cartographer_ros_msgs::msg::StatusCode::OK;
     LOG(INFO) << status_response.message;
     return status_response;
   }
@@ -534,7 +555,7 @@ cartographer_ros_msgs::StatusResponse Node::FinishTrajectoryUnderLock(
   // First, check if we can actually finish the trajectory.
   status_response = TrajectoryStateToStatus(
       trajectory_id, {TrajectoryState::ACTIVE} /* valid states */);
-  if (status_response.code != cartographer_ros_msgs::StatusCode::OK) {
+  if (status_response.code != cartographer_ros_msgs::msg::StatusCode::OK) {
     LOG(ERROR) << "Can't finish trajectory: " << status_response.message;
     return status_response;
   }
@@ -543,73 +564,73 @@ cartographer_ros_msgs::StatusResponse Node::FinishTrajectoryUnderLock(
   // A valid case with no subscribers is e.g. if we just visualize states.
   if (subscribers_.count(trajectory_id)) {
     for (auto& entry : subscribers_[trajectory_id]) {
-      entry.subscriber.shutdown();
+      entry.subscriber.reset();
       subscribed_topics_.erase(entry.topic);
       LOG(INFO) << "Shutdown the subscriber of [" << entry.topic << "]";
     }
     CHECK_EQ(subscribers_.erase(trajectory_id), 1);
   }
-  map_builder_bridge_.FinishTrajectory(trajectory_id);
+  map_builder_bridge_->FinishTrajectory(trajectory_id);
   trajectories_scheduled_for_finish_.emplace(trajectory_id);
   status_response.message =
-      absl::StrCat("Finished trajectory ", trajectory_id, ".");
-  status_response.code = cartographer_ros_msgs::StatusCode::OK;
+      "Finished trajectory " + std::to_string(trajectory_id) + ".";
+  status_response.code = cartographer_ros_msgs::msg::StatusCode::OK;
   return status_response;
 }
 
-bool Node::HandleStartTrajectory(
-    ::cartographer_ros_msgs::StartTrajectory::Request& request,
-    ::cartographer_ros_msgs::StartTrajectory::Response& response) {
+bool Node::handleStartTrajectory(
+    const cartographer_ros_msgs::srv::StartTrajectory::Request::SharedPtr request,
+    cartographer_ros_msgs::srv::StartTrajectory::Response::SharedPtr response) {
   TrajectoryOptions trajectory_options;
   std::tie(std::ignore, trajectory_options) = LoadOptions(
-      request.configuration_directory, request.configuration_basename);
+      request->configuration_directory, request->configuration_basename);
 
-  if (request.use_initial_pose) {
-    const auto pose = ToRigid3d(request.initial_pose);
+  if (request->use_initial_pose) {
+    const auto pose = ToRigid3d(request->initial_pose);
     if (!pose.IsValid()) {
-      response.status.message =
+      response->status.message =
           "Invalid pose argument. Orientation quaternion must be normalized.";
-      LOG(ERROR) << response.status.message;
-      response.status.code =
-          cartographer_ros_msgs::StatusCode::INVALID_ARGUMENT;
+      LOG(ERROR) << response->status.message;
+      response->status.code =
+          cartographer_ros_msgs::msg::StatusCode::INVALID_ARGUMENT;
       return true;
     }
 
     // Check if the requested trajectory for the relative initial pose exists.
-    response.status = TrajectoryStateToStatus(
-        request.relative_to_trajectory_id,
+    response->status = TrajectoryStateToStatus(
+        request->relative_to_trajectory_id,
         {TrajectoryState::ACTIVE, TrajectoryState::FROZEN,
          TrajectoryState::FINISHED} /* valid states */);
-    if (response.status.code != cartographer_ros_msgs::StatusCode::OK) {
+    if (response->status.code != cartographer_ros_msgs::msg::StatusCode::OK) {
       LOG(ERROR) << "Can't start a trajectory with initial pose: "
-                 << response.status.message;
+                 << response->status.message;
       return true;
     }
 
     ::cartographer::mapping::proto::InitialTrajectoryPose
         initial_trajectory_pose;
     initial_trajectory_pose.set_to_trajectory_id(
-        request.relative_to_trajectory_id);
+        request->relative_to_trajectory_id);
     *initial_trajectory_pose.mutable_relative_pose() =
         cartographer::transform::ToProto(pose);
     initial_trajectory_pose.set_timestamp(cartographer::common::ToUniversal(
-        ::cartographer_ros::FromRos(ros::Time(0))));
+        ::cartographer_ros::FromRos(rclcpp::Time(0))));
     *trajectory_options.trajectory_builder_options
          .mutable_initial_trajectory_pose() = initial_trajectory_pose;
   }
 
   if (!ValidateTrajectoryOptions(trajectory_options)) {
-    response.status.message = "Invalid trajectory options.";
-    LOG(ERROR) << response.status.message;
-    response.status.code = cartographer_ros_msgs::StatusCode::INVALID_ARGUMENT;
+    response->status.message = "Invalid trajectory options.";
+    LOG(ERROR) << response->status.message;
+    response->status.code = cartographer_ros_msgs::msg::StatusCode::INVALID_ARGUMENT;
   } else if (!ValidateTopicNames(trajectory_options)) {
-    response.status.message = "Topics are already used by another trajectory.";
-    LOG(ERROR) << response.status.message;
-    response.status.code = cartographer_ros_msgs::StatusCode::INVALID_ARGUMENT;
+    response->status.message = "Topics are already used by another trajectory.";
+    LOG(ERROR) << response->status.message;
+    response->status.code = cartographer_ros_msgs::msg::StatusCode::INVALID_ARGUMENT;
   } else {
-    response.status.message = "Success.";
-    response.trajectory_id = AddTrajectory(trajectory_options);
-    response.status.code = cartographer_ros_msgs::StatusCode::OK;
+    response->status.message = "Success.";
+    response->trajectory_id = AddTrajectory(trajectory_options);
+    response->status.code = cartographer_ros_msgs::msg::StatusCode::OK;
   }
   return true;
 }
@@ -646,92 +667,92 @@ int Node::AddOfflineTrajectory(
     const TrajectoryOptions& options) {
   absl::MutexLock lock(&mutex_);
   const int trajectory_id =
-      map_builder_bridge_.AddTrajectory(expected_sensor_ids, options);
+      map_builder_bridge_->AddTrajectory(expected_sensor_ids, options);
   AddExtrapolator(trajectory_id, options);
   AddSensorSamplers(trajectory_id, options);
   return trajectory_id;
 }
 
-bool Node::HandleGetTrajectoryStates(
-    ::cartographer_ros_msgs::GetTrajectoryStates::Request& request,
-    ::cartographer_ros_msgs::GetTrajectoryStates::Response& response) {
+bool Node::handleGetTrajectoryStates(
+    const cartographer_ros_msgs::srv::GetTrajectoryStates::Request::SharedPtr request,
+    cartographer_ros_msgs::srv::GetTrajectoryStates::Response::SharedPtr response) {
   using TrajectoryState =
       ::cartographer::mapping::PoseGraphInterface::TrajectoryState;
   absl::MutexLock lock(&mutex_);
-  response.status.code = ::cartographer_ros_msgs::StatusCode::OK;
-  response.trajectory_states.header.stamp = ros::Time::now();
-  for (const auto& entry : map_builder_bridge_.GetTrajectoryStates()) {
-    response.trajectory_states.trajectory_id.push_back(entry.first);
+  response->status.code = ::cartographer_ros_msgs::msg::StatusCode::OK;
+  response->trajectory_states.header.stamp = node_->now();
+  for (const auto& entry : map_builder_bridge_->GetTrajectoryStates()) {
+    response->trajectory_states.trajectory_id.push_back(entry.first);
     switch (entry.second) {
       case TrajectoryState::ACTIVE:
-        response.trajectory_states.trajectory_state.push_back(
-            ::cartographer_ros_msgs::TrajectoryStates::ACTIVE);
+        response->trajectory_states.trajectory_state.push_back(
+            ::cartographer_ros_msgs::msg::TrajectoryStates::ACTIVE);
         break;
       case TrajectoryState::FINISHED:
-        response.trajectory_states.trajectory_state.push_back(
-            ::cartographer_ros_msgs::TrajectoryStates::FINISHED);
+        response->trajectory_states.trajectory_state.push_back(
+            ::cartographer_ros_msgs::msg::TrajectoryStates::FINISHED);
         break;
       case TrajectoryState::FROZEN:
-        response.trajectory_states.trajectory_state.push_back(
-            ::cartographer_ros_msgs::TrajectoryStates::FROZEN);
+        response->trajectory_states.trajectory_state.push_back(
+            ::cartographer_ros_msgs::msg::TrajectoryStates::FROZEN);
         break;
       case TrajectoryState::DELETED:
-        response.trajectory_states.trajectory_state.push_back(
-            ::cartographer_ros_msgs::TrajectoryStates::DELETED);
+        response->trajectory_states.trajectory_state.push_back(
+            ::cartographer_ros_msgs::msg::TrajectoryStates::DELETED);
         break;
     }
   }
   return true;
 }
 
-bool Node::HandleFinishTrajectory(
-    ::cartographer_ros_msgs::FinishTrajectory::Request& request,
-    ::cartographer_ros_msgs::FinishTrajectory::Response& response) {
+bool Node::handleFinishTrajectory(
+    const cartographer_ros_msgs::srv::FinishTrajectory::Request::SharedPtr request,
+    cartographer_ros_msgs::srv::FinishTrajectory::Response::SharedPtr response) {
   absl::MutexLock lock(&mutex_);
-  response.status = FinishTrajectoryUnderLock(request.trajectory_id);
+  response->status = FinishTrajectoryUnderLock(request->trajectory_id);
   return true;
 }
 
-bool Node::HandleWriteState(
-    ::cartographer_ros_msgs::WriteState::Request& request,
-    ::cartographer_ros_msgs::WriteState::Response& response) {
+bool Node::handleWriteState(
+    const cartographer_ros_msgs::srv::WriteState::Request::SharedPtr request,
+    cartographer_ros_msgs::srv::WriteState::Response::SharedPtr response) {
   absl::MutexLock lock(&mutex_);
-  if (map_builder_bridge_.SerializeState(request.filename,
-                                         request.include_unfinished_submaps)) {
-    response.status.code = cartographer_ros_msgs::StatusCode::OK;
-    response.status.message =
-        absl::StrCat("State written to '", request.filename, "'.");
+  if (map_builder_bridge_->SerializeState(request->filename,
+                                         request->include_unfinished_submaps)) {
+    response->status.code = cartographer_ros_msgs::msg::StatusCode::OK;
+    response->status.message =
+        "State written to '" + request->filename + "'.";
   } else {
-    response.status.code = cartographer_ros_msgs::StatusCode::INVALID_ARGUMENT;
-    response.status.message =
-        absl::StrCat("Failed to write '", request.filename, "'.");
+    response->status.code = cartographer_ros_msgs::msg::StatusCode::INVALID_ARGUMENT;
+    response->status.message =
+        "Failed to write '" + request->filename + "'.";
   }
   return true;
 }
 
-bool Node::HandleReadMetrics(
-    ::cartographer_ros_msgs::ReadMetrics::Request& request,
-    ::cartographer_ros_msgs::ReadMetrics::Response& response) {
+bool Node::handleReadMetrics(
+    const cartographer_ros_msgs::srv::ReadMetrics::Request::SharedPtr request,
+    cartographer_ros_msgs::srv::ReadMetrics::Response::SharedPtr response) {
   absl::MutexLock lock(&mutex_);
-  response.timestamp = ros::Time::now();
+  response->timestamp = node_->now();
   if (!metrics_registry_) {
-    response.status.code = cartographer_ros_msgs::StatusCode::UNAVAILABLE;
-    response.status.message = "Collection of runtime metrics is not activated.";
+    response->status.code = cartographer_ros_msgs::msg::StatusCode::UNAVAILABLE;
+    response->status.message = "Collection of runtime metrics is not activated.";
     return true;
   }
-  metrics_registry_->ReadMetrics(&response);
-  response.status.code = cartographer_ros_msgs::StatusCode::OK;
-  response.status.message = "Successfully read metrics.";
+  metrics_registry_->ReadMetrics(response);
+  response->status.code = cartographer_ros_msgs::msg::StatusCode::OK;
+  response->status.message = "Successfully read metrics.";
   return true;
 }
 
 void Node::FinishAllTrajectories() {
   absl::MutexLock lock(&mutex_);
-  for (const auto& entry : map_builder_bridge_.GetTrajectoryStates()) {
+  for (const auto& entry : map_builder_bridge_->GetTrajectoryStates()) {
     if (entry.second == TrajectoryState::ACTIVE) {
       const int trajectory_id = entry.first;
       CHECK_EQ(FinishTrajectoryUnderLock(trajectory_id).code,
-               cartographer_ros_msgs::StatusCode::OK);
+               cartographer_ros_msgs::msg::StatusCode::OK);
     }
   }
 }
@@ -739,12 +760,12 @@ void Node::FinishAllTrajectories() {
 bool Node::FinishTrajectory(const int trajectory_id) {
   absl::MutexLock lock(&mutex_);
   return FinishTrajectoryUnderLock(trajectory_id).code ==
-         cartographer_ros_msgs::StatusCode::OK;
+         cartographer_ros_msgs::msg::StatusCode::OK;
 }
 
 void Node::RunFinalOptimization() {
   {
-    for (const auto& entry : map_builder_bridge_.GetTrajectoryStates()) {
+    for (const auto& entry : map_builder_bridge_->GetTrajectoryStates()) {
       const int trajectory_id = entry.first;
       if (entry.second == TrajectoryState::ACTIVE) {
         LOG(WARNING)
@@ -759,17 +780,17 @@ void Node::RunFinalOptimization() {
   }
   // Assuming we are not adding new data anymore, the final optimization
   // can be performed without holding the mutex.
-  map_builder_bridge_.RunFinalOptimization();
+  map_builder_bridge_->RunFinalOptimization();
 }
 
 void Node::HandleOdometryMessage(const int trajectory_id,
                                  const std::string& sensor_id,
-                                 const nav_msgs::Odometry::ConstPtr& msg) {
+                                 const nav_msgs::msg::Odometry::ConstSharedPtr& msg) {
   absl::MutexLock lock(&mutex_);
   if (!sensor_samplers_.at(trajectory_id).odometry_sampler.Pulse()) {
     return;
   }
-  auto sensor_bridge_ptr = map_builder_bridge_.sensor_bridge(trajectory_id);
+  auto sensor_bridge_ptr = map_builder_bridge_->sensor_bridge(trajectory_id);
   auto odometry_data_ptr = sensor_bridge_ptr->ToOdometryData(msg);
   if (odometry_data_ptr != nullptr) {
     extrapolators_.at(trajectory_id).AddOdometryData(*odometry_data_ptr);
@@ -779,34 +800,34 @@ void Node::HandleOdometryMessage(const int trajectory_id,
 
 void Node::HandleNavSatFixMessage(const int trajectory_id,
                                   const std::string& sensor_id,
-                                  const sensor_msgs::NavSatFix::ConstPtr& msg) {
+                                  const sensor_msgs::msg::NavSatFix::ConstSharedPtr& msg) {
   absl::MutexLock lock(&mutex_);
   if (!sensor_samplers_.at(trajectory_id).fixed_frame_pose_sampler.Pulse()) {
     return;
   }
-  map_builder_bridge_.sensor_bridge(trajectory_id)
+  map_builder_bridge_->sensor_bridge(trajectory_id)
       ->HandleNavSatFixMessage(sensor_id, msg);
 }
 
 void Node::HandleLandmarkMessage(
     const int trajectory_id, const std::string& sensor_id,
-    const cartographer_ros_msgs::LandmarkList::ConstPtr& msg) {
+    const cartographer_ros_msgs::msg::LandmarkList::ConstSharedPtr& msg) {
   absl::MutexLock lock(&mutex_);
   if (!sensor_samplers_.at(trajectory_id).landmark_sampler.Pulse()) {
     return;
   }
-  map_builder_bridge_.sensor_bridge(trajectory_id)
+  map_builder_bridge_->sensor_bridge(trajectory_id)
       ->HandleLandmarkMessage(sensor_id, msg);
 }
 
 void Node::HandleImuMessage(const int trajectory_id,
                             const std::string& sensor_id,
-                            const sensor_msgs::Imu::ConstPtr& msg) {
+                            const sensor_msgs::msg::Imu::ConstSharedPtr& msg) {
   absl::MutexLock lock(&mutex_);
   if (!sensor_samplers_.at(trajectory_id).imu_sampler.Pulse()) {
     return;
   }
-  auto sensor_bridge_ptr = map_builder_bridge_.sensor_bridge(trajectory_id);
+  auto sensor_bridge_ptr = map_builder_bridge_->sensor_bridge(trajectory_id);
   auto imu_data_ptr = sensor_bridge_ptr->ToImuData(msg);
   if (imu_data_ptr != nullptr) {
     extrapolators_.at(trajectory_id).AddImuData(*imu_data_ptr);
@@ -816,34 +837,34 @@ void Node::HandleImuMessage(const int trajectory_id,
 
 void Node::HandleLaserScanMessage(const int trajectory_id,
                                   const std::string& sensor_id,
-                                  const sensor_msgs::LaserScan::ConstPtr& msg) {
+                                  const sensor_msgs::msg::LaserScan::ConstSharedPtr& msg) {
   absl::MutexLock lock(&mutex_);
   if (!sensor_samplers_.at(trajectory_id).rangefinder_sampler.Pulse()) {
     return;
   }
-  map_builder_bridge_.sensor_bridge(trajectory_id)
+  map_builder_bridge_->sensor_bridge(trajectory_id)
       ->HandleLaserScanMessage(sensor_id, msg);
 }
 
 void Node::HandleMultiEchoLaserScanMessage(
     const int trajectory_id, const std::string& sensor_id,
-    const sensor_msgs::MultiEchoLaserScan::ConstPtr& msg) {
+    const sensor_msgs::msg::MultiEchoLaserScan::ConstSharedPtr& msg) {
   absl::MutexLock lock(&mutex_);
   if (!sensor_samplers_.at(trajectory_id).rangefinder_sampler.Pulse()) {
     return;
   }
-  map_builder_bridge_.sensor_bridge(trajectory_id)
+  map_builder_bridge_->sensor_bridge(trajectory_id)
       ->HandleMultiEchoLaserScanMessage(sensor_id, msg);
 }
 
 void Node::HandlePointCloud2Message(
     const int trajectory_id, const std::string& sensor_id,
-    const sensor_msgs::PointCloud2::ConstPtr& msg) {
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr& msg) {
   absl::MutexLock lock(&mutex_);
   if (!sensor_samplers_.at(trajectory_id).rangefinder_sampler.Pulse()) {
     return;
   }
-  map_builder_bridge_.sensor_bridge(trajectory_id)
+  map_builder_bridge_->sensor_bridge(trajectory_id)
       ->HandlePointCloud2Message(sensor_id, msg);
 }
 
@@ -851,45 +872,45 @@ void Node::SerializeState(const std::string& filename,
                           const bool include_unfinished_submaps) {
   absl::MutexLock lock(&mutex_);
   CHECK(
-      map_builder_bridge_.SerializeState(filename, include_unfinished_submaps))
+      map_builder_bridge_->SerializeState(filename, include_unfinished_submaps))
       << "Could not write state.";
 }
 
 void Node::LoadState(const std::string& state_filename,
                      const bool load_frozen_state) {
   absl::MutexLock lock(&mutex_);
-  map_builder_bridge_.LoadState(state_filename, load_frozen_state);
+  map_builder_bridge_->LoadState(state_filename, load_frozen_state);
 }
 
-void Node::MaybeWarnAboutTopicMismatch(
-    const ::ros::WallTimerEvent& unused_timer_event) {
-  ::ros::master::V_TopicInfo ros_topics;
-  ::ros::master::getTopics(ros_topics);
-  std::set<std::string> published_topics;
-  std::stringstream published_topics_string;
-  for (const auto& it : ros_topics) {
-    std::string resolved_topic = node_handle_.resolveName(it.name, false);
-    published_topics.insert(resolved_topic);
-    published_topics_string << resolved_topic << ",";
-  }
-  bool print_topics = false;
-  for (const auto& entry : subscribers_) {
-    int trajectory_id = entry.first;
-    for (const auto& subscriber : entry.second) {
-      std::string resolved_topic = node_handle_.resolveName(subscriber.topic);
-      if (published_topics.count(resolved_topic) == 0) {
-        LOG(WARNING) << "Expected topic \"" << subscriber.topic
-                     << "\" (trajectory " << trajectory_id << ")"
-                     << " (resolved topic \"" << resolved_topic << "\")"
-                     << " but no publisher is currently active.";
-        print_topics = true;
-      }
-    }
-  }
-  if (print_topics) {
-    LOG(WARNING) << "Currently available topics are: "
-                 << published_topics_string.str();
-  }
+// TODO: find ROS equivalent to ros::master::getTopics
+void Node::MaybeWarnAboutTopicMismatch() {
+//  ::ros::master::V_TopicInfo ros_topics;
+//  ::ros::master::getTopics(ros_topics);
+//  std::set<std::string> published_topics;
+//  std::stringstream published_topics_string;
+//  for (const auto& it : ros_topics) {
+//    std::string resolved_topic = node_handle_.resolveName(it.name, false);
+//    published_topics.insert(resolved_topic);
+//    published_topics_string << resolved_topic << ",";
+//  }
+//  bool print_topics = false;
+//  for (const auto& entry : subscribers_) {
+//    int trajectory_id = entry.first;
+//    for (const auto& subscriber : entry.second) {
+//      std::string resolved_topic = node_handle_.resolveName(subscriber.topic);
+//      if (published_topics.count(resolved_topic) == 0) {
+//        LOG(WARNING) << "Expected topic \"" << subscriber.topic
+//                     << "\" (trajectory " << trajectory_id << ")"
+//                     << " (resolved topic \"" << resolved_topic << "\")"
+//                     << " but no publisher is currently active.";
+//        print_topics = true;
+//      }
+//    }
+//  }
+//  if (print_topics) {
+//    LOG(WARNING) << "Currently available topics are: "
+//                 << published_topics_string.str();
+//  }
 }
 
 }  // namespace cartographer_ros

--- a/cartographer_ros/cartographer_ros/node.h
+++ b/cartographer_ros/cartographer_ros/node.h
@@ -33,23 +33,25 @@
 #include "cartographer_ros/node_constants.h"
 #include "cartographer_ros/node_options.h"
 #include "cartographer_ros/trajectory_options.h"
-#include "cartographer_ros_msgs/FinishTrajectory.h"
-#include "cartographer_ros_msgs/GetTrajectoryStates.h"
-#include "cartographer_ros_msgs/ReadMetrics.h"
-#include "cartographer_ros_msgs/StartTrajectory.h"
-#include "cartographer_ros_msgs/StatusResponse.h"
-#include "cartographer_ros_msgs/SubmapEntry.h"
-#include "cartographer_ros_msgs/SubmapList.h"
-#include "cartographer_ros_msgs/SubmapQuery.h"
-#include "cartographer_ros_msgs/WriteState.h"
-#include "nav_msgs/Odometry.h"
-#include "ros/ros.h"
-#include "sensor_msgs/Imu.h"
-#include "sensor_msgs/LaserScan.h"
-#include "sensor_msgs/MultiEchoLaserScan.h"
-#include "sensor_msgs/NavSatFix.h"
-#include "sensor_msgs/PointCloud2.h"
-#include "tf2_ros/transform_broadcaster.h"
+#include "cartographer_ros_msgs/srv/finish_trajectory.hpp"
+#include "cartographer_ros_msgs/srv/get_trajectory_states.hpp"
+#include "cartographer_ros_msgs/srv/read_metrics.hpp"
+#include "cartographer_ros_msgs/srv/start_trajectory.hpp"
+#include "cartographer_ros_msgs/msg/status_response.hpp"
+#include "cartographer_ros_msgs/msg/submap_entry.hpp"
+#include "cartographer_ros_msgs/msg/submap_list.hpp"
+#include "cartographer_ros_msgs/srv/submap_query.hpp"
+#include "cartographer_ros_msgs/srv/write_state.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+#include <sensor_msgs/msg/multi_echo_laser_scan.hpp>
+#include <sensor_msgs/msg/nav_sat_fix.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 namespace cartographer_ros {
 
@@ -58,7 +60,9 @@ class Node {
  public:
   Node(const NodeOptions& node_options,
        std::unique_ptr<cartographer::mapping::MapBuilderInterface> map_builder,
-       tf2_ros::Buffer* tf_buffer, bool collect_metrics);
+       std::shared_ptr<tf2_ros::Buffer> tf_buffer,
+       rclcpp::Node::SharedPtr node,
+       bool collect_metrics);
   ~Node();
 
   Node(const Node&) = delete;
@@ -93,21 +97,21 @@ class Node {
 
   // The following functions handle adding sensor data to a trajectory.
   void HandleOdometryMessage(int trajectory_id, const std::string& sensor_id,
-                             const nav_msgs::Odometry::ConstPtr& msg);
+                             const nav_msgs::msg::Odometry::ConstSharedPtr& msg);
   void HandleNavSatFixMessage(int trajectory_id, const std::string& sensor_id,
-                              const sensor_msgs::NavSatFix::ConstPtr& msg);
+                              const sensor_msgs::msg::NavSatFix::ConstSharedPtr& msg);
   void HandleLandmarkMessage(
       int trajectory_id, const std::string& sensor_id,
-      const cartographer_ros_msgs::LandmarkList::ConstPtr& msg);
+      const cartographer_ros_msgs::msg::LandmarkList::ConstSharedPtr& msg);
   void HandleImuMessage(int trajectory_id, const std::string& sensor_id,
-                        const sensor_msgs::Imu::ConstPtr& msg);
+                        const sensor_msgs::msg::Imu::ConstSharedPtr &msg);
   void HandleLaserScanMessage(int trajectory_id, const std::string& sensor_id,
-                              const sensor_msgs::LaserScan::ConstPtr& msg);
+                              const sensor_msgs::msg::LaserScan::ConstSharedPtr& msg);
   void HandleMultiEchoLaserScanMessage(
       int trajectory_id, const std::string& sensor_id,
-      const sensor_msgs::MultiEchoLaserScan::ConstPtr& msg);
+      const sensor_msgs::msg::MultiEchoLaserScan::ConstSharedPtr& msg);
   void HandlePointCloud2Message(int trajectory_id, const std::string& sensor_id,
-                                const sensor_msgs::PointCloud2::ConstPtr& msg);
+                                const sensor_msgs::msg::PointCloud2::ConstSharedPtr& msg);
 
   // Serializes the complete Node state.
   void SerializeState(const std::string& filename,
@@ -116,11 +120,9 @@ class Node {
   // Loads a serialized SLAM state from a .pbstream file.
   void LoadState(const std::string& state_filename, bool load_frozen_state);
 
-  ::ros::NodeHandle* node_handle();
-
  private:
   struct Subscriber {
-    ::ros::Subscriber subscriber;
+    rclcpp::SubscriptionBase::SharedPtr subscriber;
 
     // ::ros::Subscriber::getTopic() does not necessarily return the same
     // std::string
@@ -129,26 +131,27 @@ class Node {
     std::string topic;
   };
 
-  bool HandleSubmapQuery(
-      cartographer_ros_msgs::SubmapQuery::Request& request,
-      cartographer_ros_msgs::SubmapQuery::Response& response);
-  bool HandleTrajectoryQuery(
-      ::cartographer_ros_msgs::TrajectoryQuery::Request& request,
-      ::cartographer_ros_msgs::TrajectoryQuery::Response& response);
-  bool HandleStartTrajectory(
-      cartographer_ros_msgs::StartTrajectory::Request& request,
-      cartographer_ros_msgs::StartTrajectory::Response& response);
-  bool HandleFinishTrajectory(
-      cartographer_ros_msgs::FinishTrajectory::Request& request,
-      cartographer_ros_msgs::FinishTrajectory::Response& response);
-  bool HandleWriteState(cartographer_ros_msgs::WriteState::Request& request,
-                        cartographer_ros_msgs::WriteState::Response& response);
-  bool HandleGetTrajectoryStates(
-      ::cartographer_ros_msgs::GetTrajectoryStates::Request& request,
-      ::cartographer_ros_msgs::GetTrajectoryStates::Response& response);
-  bool HandleReadMetrics(
-      cartographer_ros_msgs::ReadMetrics::Request& request,
-      cartographer_ros_msgs::ReadMetrics::Response& response);
+  bool handleSubmapQuery(
+      const cartographer_ros_msgs::srv::SubmapQuery::Request::SharedPtr request,
+      cartographer_ros_msgs::srv::SubmapQuery::Response::SharedPtr response);
+  bool handleTrajectoryQuery(
+      const cartographer_ros_msgs::srv::TrajectoryQuery::Request::SharedPtr request,
+      cartographer_ros_msgs::srv::TrajectoryQuery::Response::SharedPtr response);
+  bool handleStartTrajectory(
+      const cartographer_ros_msgs::srv::StartTrajectory::Request::SharedPtr request,
+      cartographer_ros_msgs::srv::StartTrajectory::Response::SharedPtr response);
+  bool handleFinishTrajectory(
+      const cartographer_ros_msgs::srv::FinishTrajectory::Request::SharedPtr request,
+      cartographer_ros_msgs::srv::FinishTrajectory::Response::SharedPtr response);
+  bool handleWriteState(
+      const cartographer_ros_msgs::srv::WriteState::Request::SharedPtr request,
+      cartographer_ros_msgs::srv::WriteState::Response::SharedPtr response);
+  bool handleGetTrajectoryStates(
+      const cartographer_ros_msgs::srv::GetTrajectoryStates::Request::SharedPtr request,
+      cartographer_ros_msgs::srv::GetTrajectoryStates::Response::SharedPtr response);
+  bool handleReadMetrics(
+      const cartographer_ros_msgs::srv::ReadMetrics::Request::SharedPtr request,
+      cartographer_ros_msgs::srv::ReadMetrics::Response::SharedPtr response);
 
   // Returns the set of SensorIds expected for a trajectory.
   // 'SensorId::id' is the expected ROS topic name.
@@ -156,42 +159,49 @@ class Node {
   ComputeExpectedSensorIds(const TrajectoryOptions& options) const;
   int AddTrajectory(const TrajectoryOptions& options);
   void LaunchSubscribers(const TrajectoryOptions& options, int trajectory_id);
-  void PublishSubmapList(const ::ros::WallTimerEvent& timer_event);
+  void PublishSubmapList();
   void AddExtrapolator(int trajectory_id, const TrajectoryOptions& options);
   void AddSensorSamplers(int trajectory_id, const TrajectoryOptions& options);
-  void PublishLocalTrajectoryData(const ::ros::TimerEvent& timer_event);
-  void PublishTrajectoryNodeList(const ::ros::WallTimerEvent& timer_event);
-  void PublishLandmarkPosesList(const ::ros::WallTimerEvent& timer_event);
-  void PublishConstraintList(const ::ros::WallTimerEvent& timer_event);
+  void PublishLocalTrajectoryData();
+  void PublishTrajectoryNodeList();
+  void PublishLandmarkPosesList();
+  void PublishConstraintList();
   bool ValidateTrajectoryOptions(const TrajectoryOptions& options);
   bool ValidateTopicNames(const TrajectoryOptions& options);
-  cartographer_ros_msgs::StatusResponse FinishTrajectoryUnderLock(
+  cartographer_ros_msgs::msg::StatusResponse FinishTrajectoryUnderLock(
       int trajectory_id) EXCLUSIVE_LOCKS_REQUIRED(mutex_);
-  void MaybeWarnAboutTopicMismatch(const ::ros::WallTimerEvent&);
+  void MaybeWarnAboutTopicMismatch();
 
   // Helper function for service handlers that need to check trajectory states.
-  cartographer_ros_msgs::StatusResponse TrajectoryStateToStatus(
+  cartographer_ros_msgs::msg::StatusResponse TrajectoryStateToStatus(
       int trajectory_id,
       const std::set<
           cartographer::mapping::PoseGraphInterface::TrajectoryState>&
           valid_states);
   const NodeOptions node_options_;
 
-  tf2_ros::TransformBroadcaster tf_broadcaster_;
+  std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 
   absl::Mutex mutex_;
   std::unique_ptr<cartographer_ros::metrics::FamilyFactory> metrics_registry_;
-  MapBuilderBridge map_builder_bridge_ GUARDED_BY(mutex_);
+  std::shared_ptr<MapBuilderBridge> map_builder_bridge_ GUARDED_BY(mutex_);
 
-  ::ros::NodeHandle node_handle_;
-  ::ros::Publisher submap_list_publisher_;
-  ::ros::Publisher trajectory_node_list_publisher_;
-  ::ros::Publisher landmark_poses_list_publisher_;
-  ::ros::Publisher constraint_list_publisher_;
-  ::ros::Publisher tracked_pose_publisher_;
-  // These ros::ServiceServers need to live for the lifetime of the node.
-  std::vector<::ros::ServiceServer> service_servers_;
-  ::ros::Publisher scan_matched_point_cloud_publisher_;
+  rclcpp::Node::SharedPtr node_;
+  ::rclcpp::Publisher<::cartographer_ros_msgs::msg::SubmapList>::SharedPtr submap_list_publisher_;
+  ::rclcpp::Publisher<::visualization_msgs::msg::MarkerArray>::SharedPtr trajectory_node_list_publisher_;
+  ::rclcpp::Publisher<::visualization_msgs::msg::MarkerArray>::SharedPtr landmark_poses_list_publisher_;
+  ::rclcpp::Publisher<::visualization_msgs::msg::MarkerArray>::SharedPtr constraint_list_publisher_;
+  ::rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr tracked_pose_publisher_;
+  ::rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr scan_matched_point_cloud_publisher_;
+  // These ros service servers need to live for the lifetime of the node.
+  ::rclcpp::Service<cartographer_ros_msgs::srv::SubmapQuery>::SharedPtr submap_query_server_;
+  ::rclcpp::Service<cartographer_ros_msgs::srv::TrajectoryQuery>::SharedPtr trajectory_query_server;
+  ::rclcpp::Service<cartographer_ros_msgs::srv::StartTrajectory>::SharedPtr start_trajectory_server_;
+  ::rclcpp::Service<cartographer_ros_msgs::srv::FinishTrajectory>::SharedPtr finish_trajectory_server_;
+  ::rclcpp::Service<cartographer_ros_msgs::srv::WriteState>::SharedPtr write_state_server_;
+  ::rclcpp::Service<cartographer_ros_msgs::srv::GetTrajectoryStates>::SharedPtr get_trajectory_states_server_;
+  ::rclcpp::Service<cartographer_ros_msgs::srv::ReadMetrics>::SharedPtr read_metrics_server_;
+
 
   struct TrajectorySensorSamplers {
     TrajectorySensorSamplers(const double rangefinder_sampling_ratio,
@@ -214,21 +224,22 @@ class Node {
 
   // These are keyed with 'trajectory_id'.
   std::map<int, ::cartographer::mapping::PoseExtrapolator> extrapolators_;
-  std::map<int, ::ros::Time> last_published_tf_stamps_;
+  std::map<int, builtin_interfaces::msg::Time> last_published_tf_stamps_;
   std::unordered_map<int, TrajectorySensorSamplers> sensor_samplers_;
   std::unordered_map<int, std::vector<Subscriber>> subscribers_;
   std::unordered_set<std::string> subscribed_topics_;
   std::unordered_set<int> trajectories_scheduled_for_finish_;
 
-  // We have to keep the timer handles of ::ros::WallTimers around, otherwise
-  // they do not fire.
-  std::vector<::ros::WallTimer> wall_timers_;
-
   // The timer for publishing local trajectory data (i.e. pose transforms and
   // range data point clouds) is a regular timer which is not triggered when
   // simulation time is standing still. This prevents overflowing the transform
   // listener buffer by publishing the same transforms over and over again.
-  ::ros::Timer publish_local_trajectory_data_timer_;
+  ::rclcpp::TimerBase::SharedPtr submap_list_timer_;
+  ::rclcpp::TimerBase::SharedPtr local_trajectory_data_timer_;
+  ::rclcpp::TimerBase::SharedPtr trajectory_node_list_timer_;
+  ::rclcpp::TimerBase::SharedPtr landmark_pose_list_timer_;
+  ::rclcpp::TimerBase::SharedPtr constrain_list_timer_;
+  ::rclcpp::TimerBase::SharedPtr maybe_warn_about_topic_mismatch_timer_;
 };
 
 }  // namespace cartographer_ros

--- a/cartographer_ros/cartographer_ros/occupancy_grid_node_main.cc
+++ b/cartographer_ros/cartographer_ros/occupancy_grid_node_main.cc
@@ -31,11 +31,12 @@
 #include "cartographer_ros/node_constants.h"
 #include "cartographer_ros/ros_log_sink.h"
 #include "cartographer_ros/submap.h"
-#include "cartographer_ros_msgs/SubmapList.h"
-#include "cartographer_ros_msgs/SubmapQuery.h"
+#include "cartographer_ros_msgs/msg/submap_entry.hpp"
+#include "cartographer_ros_msgs/msg/submap_list.hpp"
+#include "cartographer_ros_msgs/srv/submap_query.hpp"
 #include "gflags/gflags.h"
-#include "nav_msgs/OccupancyGrid.h"
-#include "ros/ros.h"
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 DEFINE_double(resolution, 0.05,
               "Resolution of a grid cell in the published occupancy grid.");
@@ -54,7 +55,8 @@ using ::cartographer::io::PaintSubmapSlicesResult;
 using ::cartographer::io::SubmapSlice;
 using ::cartographer::mapping::SubmapId;
 
-class Node {
+class Node : public rclcpp::Node
+{
  public:
   explicit Node(double resolution, double publish_period_sec);
   ~Node() {}
@@ -63,130 +65,144 @@ class Node {
   Node& operator=(const Node&) = delete;
 
  private:
-  void HandleSubmapList(const cartographer_ros_msgs::SubmapList::ConstPtr& msg);
-  void DrawAndPublish(const ::ros::WallTimerEvent& timer_event);
+  void HandleSubmapList(const cartographer_ros_msgs::msg::SubmapList::ConstSharedPtr& msg);
+  void DrawAndPublish();
 
-  ::ros::NodeHandle node_handle_;
   const double resolution_;
 
   absl::Mutex mutex_;
-  ::ros::ServiceClient client_ GUARDED_BY(mutex_);
-  ::ros::Subscriber submap_list_subscriber_ GUARDED_BY(mutex_);
-  ::ros::Publisher occupancy_grid_publisher_ GUARDED_BY(mutex_);
+  rclcpp::CallbackGroup::SharedPtr callback_group_;
+  rclcpp::executors::SingleThreadedExecutor::SharedPtr callback_group_executor_;
+  ::rclcpp::Client<cartographer_ros_msgs::srv::SubmapQuery>::SharedPtr client_ GUARDED_BY(mutex_);
+  ::rclcpp::Subscription<cartographer_ros_msgs::msg::SubmapList>::SharedPtr submap_list_subscriber_ GUARDED_BY(mutex_);
+  ::rclcpp::Publisher<::nav_msgs::msg::OccupancyGrid>::SharedPtr occupancy_grid_publisher_ GUARDED_BY(mutex_);
   std::map<SubmapId, SubmapSlice> submap_slices_ GUARDED_BY(mutex_);
-  ::ros::WallTimer occupancy_grid_publisher_timer_;
+  rclcpp::TimerBase::SharedPtr occupancy_grid_publisher_timer_;
   std::string last_frame_id_;
-  ros::Time last_timestamp_;
+  rclcpp::Time last_timestamp_;
 };
 
 Node::Node(const double resolution, const double publish_period_sec)
-    : resolution_(resolution),
-      client_(node_handle_.serviceClient<::cartographer_ros_msgs::SubmapQuery>(
-          kSubmapQueryServiceName)),
-      submap_list_subscriber_(node_handle_.subscribe(
-          kSubmapListTopic, kLatestOnlyPublisherQueueSize,
-          boost::function<void(
-              const cartographer_ros_msgs::SubmapList::ConstPtr&)>(
-              [this](const cartographer_ros_msgs::SubmapList::ConstPtr& msg) {
-                HandleSubmapList(msg);
-              }))),
-      occupancy_grid_publisher_(
-          node_handle_.advertise<::nav_msgs::OccupancyGrid>(
-              FLAGS_occupancy_grid_topic, kLatestOnlyPublisherQueueSize,
-              true /* latched */)),
-      occupancy_grid_publisher_timer_(
-          node_handle_.createWallTimer(::ros::WallDuration(publish_period_sec),
-                                       &Node::DrawAndPublish, this)) {}
+    : rclcpp::Node("cartographer_occupancy_grid_node"),
+      resolution_(resolution)
+{
+  callback_group_ = this->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive,
+    false);
+  callback_group_executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+  callback_group_executor_->add_callback_group(callback_group_, this->get_node_base_interface());
+  client_ = this->create_client<cartographer_ros_msgs::srv::SubmapQuery>(
+        kSubmapQueryServiceName,
+        rmw_qos_profile_services_default,
+        callback_group_
+        );
 
-void Node::HandleSubmapList(
-    const cartographer_ros_msgs::SubmapList::ConstPtr& msg) {
-  absl::MutexLock locker(&mutex_);
+  occupancy_grid_publisher_ = this->create_publisher<::nav_msgs::msg::OccupancyGrid>(
+      kOccupancyGridTopic, rclcpp::QoS(10).transient_local());
 
-  // We do not do any work if nobody listens.
-  if (occupancy_grid_publisher_.getNumSubscribers() == 0) {
-    return;
-  }
+  occupancy_grid_publisher_timer_ = this->create_wall_timer(
+    std::chrono::milliseconds(int(publish_period_sec * 1000)),
+    [this]() {
+      DrawAndPublish();
+    });
 
-  // Keep track of submap IDs that don't appear in the message anymore.
-  std::set<SubmapId> submap_ids_to_delete;
-  for (const auto& pair : submap_slices_) {
-    submap_ids_to_delete.insert(pair.first);
-  }
+  auto handleSubmapList =
+    [this, publish_period_sec](const typename cartographer_ros_msgs::msg::SubmapList::SharedPtr msg) -> void
+    {
+    absl::MutexLock locker(&mutex_);
 
-  for (const auto& submap_msg : msg->submap) {
-    const SubmapId id{submap_msg.trajectory_id, submap_msg.submap_index};
-    submap_ids_to_delete.erase(id);
-    if ((submap_msg.is_frozen && !FLAGS_include_frozen_submaps) ||
-        (!submap_msg.is_frozen && !FLAGS_include_unfrozen_submaps)) {
-      continue;
-    }
-    SubmapSlice& submap_slice = submap_slices_[id];
-    submap_slice.pose = ToRigid3d(submap_msg.pose);
-    submap_slice.metadata_version = submap_msg.submap_version;
-    if (submap_slice.surface != nullptr &&
-        submap_slice.version == submap_msg.submap_version) {
-      continue;
+    // We do not do any work if nobody listens.
+    if (this->count_publishers(kSubmapListTopic) == 0){
+      return;
     }
 
-    auto fetched_textures =
-        ::cartographer_ros::FetchSubmapTextures(id, &client_);
-    if (fetched_textures == nullptr) {
-      continue;
+    // Keep track of submap IDs that don't appear in the message anymore.
+    std::set<SubmapId> submap_ids_to_delete;
+    for (const auto& pair : submap_slices_) {
+      submap_ids_to_delete.insert(pair.first);
     }
-    CHECK(!fetched_textures->textures.empty());
-    submap_slice.version = fetched_textures->version;
 
-    // We use the first texture only. By convention this is the highest
-    // resolution texture and that is the one we want to use to construct the
-    // map for ROS.
-    const auto fetched_texture = fetched_textures->textures.begin();
-    submap_slice.width = fetched_texture->width;
-    submap_slice.height = fetched_texture->height;
-    submap_slice.slice_pose = fetched_texture->slice_pose;
-    submap_slice.resolution = fetched_texture->resolution;
-    submap_slice.cairo_data.clear();
-    submap_slice.surface = ::cartographer::io::DrawTexture(
-        fetched_texture->pixels.intensity, fetched_texture->pixels.alpha,
-        fetched_texture->width, fetched_texture->height,
-        &submap_slice.cairo_data);
-  }
+    for (const auto& submap_msg : msg->submap) {
+      const SubmapId id{submap_msg.trajectory_id, submap_msg.submap_index};
+      submap_ids_to_delete.erase(id);
+      if ((submap_msg.is_frozen && !FLAGS_include_frozen_submaps) ||
+          (!submap_msg.is_frozen && !FLAGS_include_unfrozen_submaps)) {
+        continue;
+      }
+      SubmapSlice& submap_slice = submap_slices_[id];
+      submap_slice.pose = ToRigid3d(submap_msg.pose);
+      submap_slice.metadata_version = submap_msg.submap_version;
+      if (submap_slice.surface != nullptr &&
+          submap_slice.version == submap_msg.submap_version) {
+        continue;
+      }
 
-  // Delete all submaps that didn't appear in the message.
-  for (const auto& id : submap_ids_to_delete) {
-    submap_slices_.erase(id);
-  }
+      auto fetched_textures = cartographer_ros::FetchSubmapTextures(
+            id, client_, callback_group_executor_,
+            std::chrono::milliseconds(int(publish_period_sec * 1000)));
+      if (fetched_textures == nullptr) {
+        continue;
+      }
+      CHECK(!fetched_textures->textures.empty());
+      submap_slice.version = fetched_textures->version;
 
-  last_timestamp_ = msg->header.stamp;
-  last_frame_id_ = msg->header.frame_id;
+      // We use the first texture only. By convention this is the highest
+      // resolution texture and that is the one we want to use to construct the
+      // map for ROS.
+      const auto fetched_texture = fetched_textures->textures.begin();
+      submap_slice.width = fetched_texture->width;
+      submap_slice.height = fetched_texture->height;
+      submap_slice.slice_pose = fetched_texture->slice_pose;
+      submap_slice.resolution = fetched_texture->resolution;
+      submap_slice.cairo_data.clear();
+      submap_slice.surface = ::cartographer::io::DrawTexture(
+          fetched_texture->pixels.intensity, fetched_texture->pixels.alpha,
+          fetched_texture->width, fetched_texture->height,
+          &submap_slice.cairo_data);
+    }
+
+    // Delete all submaps that didn't appear in the message.
+    for (const auto& id : submap_ids_to_delete) {
+      submap_slices_.erase(id);
+    }
+
+    last_timestamp_ = msg->header.stamp;
+    last_frame_id_ = msg->header.frame_id;
+    };
+
+  submap_list_subscriber_ = create_subscription<cartographer_ros_msgs::msg::SubmapList>(
+    kSubmapListTopic, rclcpp::QoS(10), handleSubmapList);
 }
 
-void Node::DrawAndPublish(const ::ros::WallTimerEvent& unused_timer_event) {
+void Node::DrawAndPublish() {
   absl::MutexLock locker(&mutex_);
   if (submap_slices_.empty() || last_frame_id_.empty()) {
     return;
   }
   auto painted_slices = PaintSubmapSlices(submap_slices_, resolution_);
-  std::unique_ptr<nav_msgs::OccupancyGrid> msg_ptr = CreateOccupancyGridMsg(
+  std::unique_ptr<nav_msgs::msg::OccupancyGrid> msg_ptr = CreateOccupancyGridMsg(
       painted_slices, resolution_, last_frame_id_, last_timestamp_);
-  occupancy_grid_publisher_.publish(*msg_ptr);
+  occupancy_grid_publisher_->publish(*msg_ptr);
 }
 
 }  // namespace
 }  // namespace cartographer_ros
 
 int main(int argc, char** argv) {
+  // Init rclcpp first because gflags reorders command line flags in argv
+  rclcpp::init(argc, argv);
+
+  google::AllowCommandLineReparsing();
   google::InitGoogleLogging(argv[0]);
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  google::ParseCommandLineFlags(&argc, &argv, false);
 
   CHECK(FLAGS_include_frozen_submaps || FLAGS_include_unfrozen_submaps)
       << "Ignoring both frozen and unfrozen submaps makes no sense.";
 
-  ::ros::init(argc, argv, "cartographer_occupancy_grid_node");
-  ::ros::start();
-
   cartographer_ros::ScopedRosLogSink ros_log_sink;
-  ::cartographer_ros::Node node(FLAGS_resolution, FLAGS_publish_period_sec);
+  auto node = std::make_shared<cartographer_ros::Node>(FLAGS_resolution, FLAGS_publish_period_sec);
 
-  ::ros::spin();
-  ::ros::shutdown();
+  rclcpp::spin(node);
+  ::rclcpp::shutdown();
+  return 0;
 }

--- a/cartographer_ros/cartographer_ros/offline_node.h
+++ b/cartographer_ros/cartographer_ros/offline_node.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+#include <rclcpp/rclcpp.hpp>
 #include "cartographer/mapping/map_builder_interface.h"
 #include "cartographer_ros/node_options.h"
 
@@ -31,7 +32,8 @@ using MapBuilderFactory =
     std::function<std::unique_ptr<::cartographer::mapping::MapBuilderInterface>(
         const ::cartographer::mapping::proto::MapBuilderOptions&)>;
 
-void RunOfflineNode(const MapBuilderFactory& map_builder_factory);
+void RunOfflineNode(const MapBuilderFactory& map_builder_factory,
+                    rclcpp::Node::SharedPtr cartographer_offline_node);
 
 }  // namespace cartographer_ros
 

--- a/cartographer_ros/cartographer_ros/offline_node_main.cc
+++ b/cartographer_ros/cartographer_ros/offline_node_main.cc
@@ -18,14 +18,14 @@
 #include "cartographer_ros/offline_node.h"
 #include "cartographer_ros/ros_log_sink.h"
 #include "gflags/gflags.h"
-#include "ros/ros.h"
+#include <rclcpp/rclcpp.hpp>
 
 int main(int argc, char** argv) {
-  google::InitGoogleLogging(argv[0]);
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  rclcpp::init(argc, argv);
 
-  ::ros::init(argc, argv, "cartographer_offline_node");
-  ::ros::start();
+  google::AllowCommandLineReparsing();
+  google::InitGoogleLogging(argv[0]);
+  google::ParseCommandLineFlags(&argc, &argv, false);
 
   cartographer_ros::ScopedRosLogSink ros_log_sink;
 
@@ -35,7 +35,9 @@ int main(int argc, char** argv) {
     return ::cartographer::mapping::CreateMapBuilder(map_builder_options);
   };
 
-  cartographer_ros::RunOfflineNode(map_builder_factory);
+  rclcpp::Node::SharedPtr cartographer_offline_node =
+      rclcpp::Node::make_shared("cartographer_offline_node");
+  cartographer_ros::RunOfflineNode(map_builder_factory, cartographer_offline_node);
 
-  ::ros::shutdown();
+  rclcpp::shutdown();
 }

--- a/cartographer_ros/cartographer_ros/pbstream_map_publisher_main.cc
+++ b/cartographer_ros/cartographer_ros/pbstream_map_publisher_main.cc
@@ -31,8 +31,8 @@
 #include "cartographer_ros/ros_map.h"
 #include "gflags/gflags.h"
 #include "glog/logging.h"
-#include "nav_msgs/OccupancyGrid.h"
-#include "ros/ros.h"
+#include <nav_msgs/msg/occupancy_grid.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 DEFINE_string(pbstream_filename, "",
               "Filename of a pbstream to draw a map from.");
@@ -43,7 +43,7 @@ DEFINE_double(resolution, 0.05, "Resolution of a grid cell in the drawn map.");
 namespace cartographer_ros {
 namespace {
 
-std::unique_ptr<nav_msgs::OccupancyGrid> LoadOccupancyGridMsg(
+std::unique_ptr<nav_msgs::msg::OccupancyGrid> LoadOccupancyGridMsg(
     const std::string& pbstream_filename, const double resolution) {
   ::cartographer::io::ProtoStreamReader reader(pbstream_filename);
   ::cartographer::io::ProtoStreamDeserializer deserializer(&reader);
@@ -60,40 +60,42 @@ std::unique_ptr<nav_msgs::OccupancyGrid> LoadOccupancyGridMsg(
   const auto painted_slices =
       ::cartographer::io::PaintSubmapSlices(submap_slices, resolution);
   return CreateOccupancyGridMsg(painted_slices, resolution, FLAGS_map_frame_id,
-                                ros::Time::now());
+                                rclcpp::Clock().now());
 }
 
 void Run(const std::string& pbstream_filename, const std::string& map_topic,
          const std::string& map_frame_id, const double resolution) {
-  std::unique_ptr<nav_msgs::OccupancyGrid> msg_ptr =
+  rclcpp::Node::SharedPtr cartographer_pbstream_map_publisher_node =
+      rclcpp::Node::make_shared("cartographer_pbstream_map_publisher");
+  std::unique_ptr<nav_msgs::msg::OccupancyGrid> msg_ptr =
       LoadOccupancyGridMsg(pbstream_filename, resolution);
 
-  ::ros::NodeHandle node_handle("");
-  ::ros::Publisher pub = node_handle.advertise<nav_msgs::OccupancyGrid>(
-      map_topic, kLatestOnlyPublisherQueueSize, true /*latched */);
+  auto pub = cartographer_pbstream_map_publisher_node->create_publisher<nav_msgs::msg::OccupancyGrid>(
+      map_topic, rclcpp::QoS(1).transient_local());
 
   LOG(INFO) << "Publishing occupancy grid topic " << map_topic
             << " (frame_id: " << map_frame_id
             << ", resolution:" << std::to_string(resolution) << ").";
-  pub.publish(*msg_ptr);
-  ::ros::spin();
-  ::ros::shutdown();
+  pub->publish(*msg_ptr);
+  rclcpp::spin(cartographer_pbstream_map_publisher_node);
 }
 
 }  // namespace
 }  // namespace cartographer_ros
 
 int main(int argc, char** argv) {
+  // Init rclcpp first because gflags reorders command line flags in argv
+  rclcpp::init(argc, argv);
+
+  google::AllowCommandLineReparsing();
   google::InitGoogleLogging(argv[0]);
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  google::ParseCommandLineFlags(&argc, &argv, false);
 
   CHECK(!FLAGS_pbstream_filename.empty()) << "-pbstream_filename is missing.";
-
-  ::ros::init(argc, argv, "cartographer_pbstream_map_publisher");
-  ::ros::start();
 
   cartographer_ros::ScopedRosLogSink ros_log_sink;
 
   ::cartographer_ros::Run(FLAGS_pbstream_filename, FLAGS_map_topic,
                           FLAGS_map_frame_id, FLAGS_resolution);
+  ::rclcpp::shutdown();
 }

--- a/cartographer_ros/cartographer_ros/pbstream_to_ros_map_main.cc
+++ b/cartographer_ros/cartographer_ros/pbstream_to_ros_map_main.cc
@@ -26,6 +26,7 @@
 #include "cartographer_ros/ros_map.h"
 #include "gflags/gflags.h"
 #include "glog/logging.h"
+#include <rclcpp/rclcpp.hpp>
 
 DEFINE_string(pbstream_filename, "",
               "Filename of a pbstream to draw a map from.");
@@ -69,13 +70,18 @@ void Run(const std::string& pbstream_filename, const std::string& map_filestem,
 }  // namespace cartographer_ros
 
 int main(int argc, char** argv) {
+  // Init rclcpp first because gflags reorders command line flags in argv
+  rclcpp::init(argc, argv);
+
+  google::AllowCommandLineReparsing();
   FLAGS_alsologtostderr = true;
   google::InitGoogleLogging(argv[0]);
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  google::ParseCommandLineFlags(&argc, &argv, false);
 
   CHECK(!FLAGS_pbstream_filename.empty()) << "-pbstream_filename is missing.";
   CHECK(!FLAGS_map_filestem.empty()) << "-map_filestem is missing.";
 
   ::cartographer_ros::Run(FLAGS_pbstream_filename, FLAGS_map_filestem,
                           FLAGS_resolution);
+  rclcpp::shutdown();
 }

--- a/cartographer_ros/cartographer_ros/playable_bag.cc
+++ b/cartographer_ros/cartographer_ros/playable_bag.cc
@@ -19,49 +19,58 @@
 #include "absl/memory/memory.h"
 #include "cartographer_ros/node_constants.h"
 #include "glog/logging.h"
-#include "tf2_msgs/TFMessage.h"
+#include "tf2_msgs/msg/tf_message.hpp"
+#include "rosbag2_storage/topic_metadata.hpp"
+#include "rosbag2_storage/bag_metadata.hpp"
 
 namespace cartographer_ros {
 
 PlayableBag::PlayableBag(
     const std::string& bag_filename, const int bag_id,
-    const ros::Time start_time, const ros::Time end_time,
-    const ros::Duration buffer_delay,
+    const rclcpp::Duration buffer_delay,
     FilteringEarlyMessageHandler filtering_early_message_handler)
-    : bag_(absl::make_unique<rosbag::Bag>(bag_filename, rosbag::bagmode::Read)),
-      view_(absl::make_unique<rosbag::View>(*bag_, start_time, end_time)),
-      view_iterator_(view_->begin()),
+    : bag_reader_(std::make_unique<rosbag2_cpp::Reader>()),
       finished_(false),
       bag_id_(bag_id),
       bag_filename_(bag_filename),
-      duration_in_seconds_(
-          (view_->getEndTime() - view_->getBeginTime()).toSec()),
       message_counter_(0),
       buffer_delay_(buffer_delay),
       filtering_early_message_handler_(
           std::move(filtering_early_message_handler)) {
+  LOG(WARNING) << "Opening bag: " << bag_filename;
+  bag_reader_->open(bag_filename);
+  bag_metadata = bag_reader_->get_metadata();
+  duration_in_seconds_ = bag_metadata.duration.count()/1e9;
+  LOG(WARNING) << "duration_in_seconds_: " << duration_in_seconds_;
+  LOG(WARNING) << "message_count: " << bag_metadata.message_count;
+  LOG(WARNING) << "compression_mode: " << bag_metadata.compression_mode;
+  LOG(WARNING) << "compression_format: " << bag_metadata.compression_format;
   AdvanceUntilMessageAvailable();
-  for (const auto* connection_info : view_->getConnections()) {
-    topics_.insert(connection_info->topic);
+  for (auto topic_info : bag_metadata.topics_with_message_count) {
+    topics_.insert(topic_info.topic_metadata.name);
   }
 }
 
-ros::Time PlayableBag::PeekMessageTime() const {
+rclcpp::Time PlayableBag::PeekMessageTime() const {
   CHECK(IsMessageAvailable());
-  return buffered_messages_.front().getTime();
+  return rclcpp::Time(buffered_messages_.front().time_stamp);
 }
 
-std::tuple<ros::Time, ros::Time> PlayableBag::GetBeginEndTime() const {
-  return std::make_tuple(view_->getBeginTime(), view_->getEndTime());
+std::tuple<rclcpp::Time, rclcpp::Time> PlayableBag::GetBeginEndTime() const {
+  return std::make_tuple(
+    rclcpp::Time(bag_metadata.starting_time.time_since_epoch().count()),
+    rclcpp::Time(bag_metadata.starting_time.time_since_epoch().count() + bag_metadata.duration.count()));
 }
 
-rosbag::MessageInstance PlayableBag::GetNextMessage(
-    cartographer_ros_msgs::BagfileProgress* progress) {
+rosbag2_storage::SerializedBagMessage PlayableBag::GetNextMessage(
+    cartographer_ros_msgs::msg::BagfileProgress* progress) {
   CHECK(IsMessageAvailable());
-  const rosbag::MessageInstance msg = buffered_messages_.front();
+  const rosbag2_storage::SerializedBagMessage msg = buffered_messages_.front();
   buffered_messages_.pop_front();
   AdvanceUntilMessageAvailable();
-  double processed_seconds = (msg.getTime() - view_->getBeginTime()).toSec();
+  double processed_seconds =
+      (rclcpp::Time(msg.time_stamp) -
+       rclcpp::Time(bag_metadata.starting_time.time_since_epoch().count())).seconds();
   if ((message_counter_ % 10000) == 0) {
     LOG(INFO) << "Processed " << processed_seconds << " of "
               << duration_in_seconds_ << " seconds of bag " << bag_filename_;
@@ -70,7 +79,7 @@ rosbag::MessageInstance PlayableBag::GetNextMessage(
   if (progress) {
     progress->current_bagfile_name = bag_filename_;
     progress->current_bagfile_id = bag_id_;
-    progress->total_messages = view_->size();
+    progress->total_messages = bag_metadata.message_count;
     progress->processed_messages = message_counter_;
     progress->total_seconds = duration_in_seconds_;
     progress->processed_seconds = processed_seconds;
@@ -81,24 +90,23 @@ rosbag::MessageInstance PlayableBag::GetNextMessage(
 
 bool PlayableBag::IsMessageAvailable() const {
   return !buffered_messages_.empty() &&
-         (buffered_messages_.front().getTime() <
-          buffered_messages_.back().getTime() - buffer_delay_);
+         (buffered_messages_.front().time_stamp <
+          buffered_messages_.back().time_stamp - buffer_delay_.nanoseconds());
 }
 
 int PlayableBag::bag_id() const { return bag_id_; }
 
 void PlayableBag::AdvanceOneMessage() {
   CHECK(!finished_);
-  if (view_iterator_ == view_->end()) {
+  if (!bag_reader_->has_next()) {
     finished_ = true;
     return;
   }
-  rosbag::MessageInstance& msg = *view_iterator_;
+  auto msg = bag_reader_->read_next();
   if (!filtering_early_message_handler_ ||
       filtering_early_message_handler_(msg)) {
-    buffered_messages_.push_back(msg);
+    buffered_messages_.push_back(*msg);
   }
-  ++view_iterator_;
   ++message_counter_;
 }
 
@@ -111,10 +119,15 @@ void PlayableBag::AdvanceUntilMessageAvailable() {
   } while (!finished_ && !IsMessageAvailable());
 }
 
-PlayableBagMultiplexer::PlayableBagMultiplexer() : pnh_("~") {
-  bag_progress_pub_ = pnh_.advertise<cartographer_ros_msgs::BagfileProgress>(
+PlayableBagMultiplexer::PlayableBagMultiplexer(rclcpp::Node::SharedPtr node) {
+  node_ = node;
+  bag_progress_pub_ = node_->create_publisher<cartographer_ros_msgs::msg::BagfileProgress>(
       "bagfile_progress", 10);
-  progress_pub_interval_ = pnh_.param("bagfile_progress_pub_interval", 10.0);
+  if (!node_->has_parameter("bagfile_progress_pub_interval")) {
+    node_->declare_parameter("bagfile_progress_pub_interval", progress_pub_interval_);
+  }
+  progress_pub_interval_ =
+      node_->get_parameter_or("bagfile_progress_pub_interval", progress_pub_interval_, 10.0);
 }
 
 void PlayableBagMultiplexer::AddPlayableBag(PlayableBag playable_bag) {
@@ -126,43 +139,51 @@ void PlayableBagMultiplexer::AddPlayableBag(PlayableBag playable_bag) {
   next_message_queue_.emplace(
       BagMessageItem{playable_bags_.back().PeekMessageTime(),
                      static_cast<int>(playable_bags_.size() - 1)});
-  bag_progress_time_map_[playable_bag.bag_id()] = ros::Time::now();
+  bag_progress_time_map_[playable_bag.bag_id()] = node_->now();
 }
 
 bool PlayableBagMultiplexer::IsMessageAvailable() const {
   return !next_message_queue_.empty();
 }
 
-std::tuple<rosbag::MessageInstance, int, bool>
-PlayableBagMultiplexer::GetNextMessage() {
+std::tuple<rosbag2_storage::SerializedBagMessage, int, std::string, bool> PlayableBagMultiplexer::GetNextMessage() {
   CHECK(IsMessageAvailable());
   const int current_bag_index = next_message_queue_.top().bag_index;
   PlayableBag& current_bag = playable_bags_.at(current_bag_index);
-  cartographer_ros_msgs::BagfileProgress progress;
-  rosbag::MessageInstance msg = current_bag.GetNextMessage(&progress);
+  cartographer_ros_msgs::msg::BagfileProgress progress;
+  rosbag2_storage::SerializedBagMessage msg = current_bag.GetNextMessage(&progress);
   const bool publish_progress =
       current_bag.finished() ||
-      ros::Time::now() - bag_progress_time_map_[current_bag.bag_id()] >=
-          ros::Duration(progress_pub_interval_);
-  if (bag_progress_pub_.getNumSubscribers() > 0 && publish_progress) {
+      node_->now() - bag_progress_time_map_[current_bag.bag_id()] >=
+          rclcpp::Duration(progress_pub_interval_, 0);
+  if (bag_progress_pub_->get_subscription_count() > 0 && publish_progress) {
     progress.total_bagfiles = playable_bags_.size();
     if (current_bag.finished()) {
       progress.processed_seconds = current_bag.duration_in_seconds();
     }
-    bag_progress_pub_.publish(progress);
-    bag_progress_time_map_[current_bag.bag_id()] = ros::Time::now();
+    bag_progress_pub_->publish(progress);
+    bag_progress_time_map_[current_bag.bag_id()] = node_->now();
   }
-  CHECK_EQ(msg.getTime(), next_message_queue_.top().message_timestamp);
+  CHECK_EQ(msg.time_stamp, next_message_queue_.top().message_timestamp.nanoseconds());
   next_message_queue_.pop();
   if (current_bag.IsMessageAvailable()) {
     next_message_queue_.emplace(
         BagMessageItem{current_bag.PeekMessageTime(), current_bag_index});
   }
-  return std::make_tuple(std::move(msg), current_bag.bag_id(),
+
+  std::string topic_type;
+  for (auto topic_info : current_bag.bag_metadata.topics_with_message_count) {
+    if (topic_info.topic_metadata.name == msg.topic_name){
+      topic_type = topic_info.topic_metadata.type;
+      break;
+    }
+  }
+
+  return std::make_tuple(std::move(msg), current_bag.bag_id(), topic_type,
                          !current_bag.IsMessageAvailable());
 }
 
-ros::Time PlayableBagMultiplexer::PeekMessageTime() const {
+rclcpp::Time PlayableBagMultiplexer::PeekMessageTime() const {
   CHECK(IsMessageAvailable());
   return next_message_queue_.top().message_timestamp;
 }

--- a/cartographer_ros/cartographer_ros/ros_log_sink.cc
+++ b/cartographer_ros/cartographer_ros/ros_log_sink.cc
@@ -22,7 +22,6 @@
 #include <thread>
 
 #include "glog/log_severity.h"
-#include "ros/console.h"
 
 namespace cartographer_ros {
 
@@ -48,19 +47,19 @@ void ScopedRosLogSink::send(const ::google::LogSeverity severity,
       severity, GetBasename(filename), line, tm_time, message, message_len);
   switch (severity) {
     case ::google::GLOG_INFO:
-      ROS_INFO_STREAM(message_string);
+      RCLCPP_INFO_STREAM(logger_, message_string);
       break;
 
     case ::google::GLOG_WARNING:
-      ROS_WARN_STREAM(message_string);
+      RCLCPP_WARN_STREAM(logger_, message_string);
       break;
 
     case ::google::GLOG_ERROR:
-      ROS_ERROR_STREAM(message_string);
+      RCLCPP_ERROR_STREAM(logger_, message_string);
       break;
 
     case ::google::GLOG_FATAL:
-      ROS_FATAL_STREAM(message_string);
+      RCLCPP_FATAL_STREAM(logger_, message_string);
       will_die_ = true;
       break;
   }

--- a/cartographer_ros/cartographer_ros/ros_log_sink.h
+++ b/cartographer_ros/cartographer_ros/ros_log_sink.h
@@ -20,6 +20,7 @@
 #include <ctime>
 
 #include "glog/logging.h"
+#include <rclcpp/rclcpp.hpp>
 
 namespace cartographer_ros {
 
@@ -38,6 +39,7 @@ class ScopedRosLogSink : public ::google::LogSink {
 
  private:
   bool will_die_;
+  rclcpp::Logger logger_{rclcpp::get_logger("cartographer logger")};
 };
 
 }  // namespace cartographer_ros

--- a/cartographer_ros/cartographer_ros/ros_map.cc
+++ b/cartographer_ros/cartographer_ros/ros_map.cc
@@ -16,15 +16,14 @@
 
 #include "cartographer_ros/ros_map.h"
 
-#include "absl/strings/str_cat.h"
-
 namespace cartographer_ros {
 
+// TODO: png ?
 void WritePgm(const ::cartographer::io::Image& image, const double resolution,
               ::cartographer::io::FileWriter* file_writer) {
   const std::string header =
-      absl::StrCat("P5\n# Cartographer map; ", resolution, " m/pixel\n",
-                   image.width(), " ", image.height(), "\n255\n");
+      "P5\n# Cartographer map; " + std::to_string(resolution) + " m/pixel\n" +
+      std::to_string(image.width()) + " " + std::to_string(image.height()) + "\n255\n";
   file_writer->Write(header.data(), header.size());
   for (int y = 0; y < image.height(); ++y) {
     for (int x = 0; x < image.width(); ++x) {
@@ -39,10 +38,11 @@ void WriteYaml(const double resolution, const Eigen::Vector2d& origin,
                ::cartographer::io::FileWriter* file_writer) {
   // Magic constants taken directly from ros map_saver code:
   // https://github.com/ros-planning/navigation/blob/ac41d2480c4cf1602daf39a6e9629142731d92b0/map_server/src/map_saver.cpp#L114
-  const std::string output = absl::StrCat(
-      "image: ", pgm_filename, "\n", "resolution: ", resolution, "\n",
-      "origin: [", origin.x(), ", ", origin.y(),
-      ", 0.0]\nnegate: 0\noccupied_thresh: 0.65\nfree_thresh: 0.196\n");
+  // TODO: check ROS2 map format
+  const std::string output =
+      "image: " + pgm_filename + "\n" + "resolution: " + std::to_string(resolution) + "\n" +
+      "origin: [" + std::to_string(origin.x()) + ", " + std::to_string(origin.y()) +
+      ", 0.0]\nnegate: 0\noccupied_thresh: 0.65\nfree_thresh: 0.196\n";
   file_writer->Write(output.data(), output.size());
 }
 

--- a/cartographer_ros/cartographer_ros/sensor_bridge.cc
+++ b/cartographer_ros/cartographer_ros/sensor_bridge.cc
@@ -49,7 +49,7 @@ SensorBridge::SensorBridge(
       trajectory_builder_(trajectory_builder) {}
 
 std::unique_ptr<carto::sensor::OdometryData> SensorBridge::ToOdometryData(
-    const nav_msgs::Odometry::ConstPtr& msg) {
+    const nav_msgs::msg::Odometry::ConstSharedPtr& msg) {
   const carto::common::Time time = FromRos(msg->header.stamp);
   const auto sensor_to_tracking = tf_bridge_.LookupToTracking(
       time, CheckNoLeadingSlash(msg->child_frame_id));
@@ -62,7 +62,7 @@ std::unique_ptr<carto::sensor::OdometryData> SensorBridge::ToOdometryData(
 }
 
 void SensorBridge::HandleOdometryMessage(
-    const std::string& sensor_id, const nav_msgs::Odometry::ConstPtr& msg) {
+    const std::string& sensor_id, const nav_msgs::msg::Odometry::ConstSharedPtr& msg) {
   std::unique_ptr<carto::sensor::OdometryData> odometry_data =
       ToOdometryData(msg);
   if (odometry_data != nullptr) {
@@ -73,9 +73,9 @@ void SensorBridge::HandleOdometryMessage(
 }
 
 void SensorBridge::HandleNavSatFixMessage(
-    const std::string& sensor_id, const sensor_msgs::NavSatFix::ConstPtr& msg) {
+    const std::string& sensor_id, const sensor_msgs::msg::NavSatFix::ConstSharedPtr& msg) {
   const carto::common::Time time = FromRos(msg->header.stamp);
-  if (msg->status.status == sensor_msgs::NavSatStatus::STATUS_NO_FIX) {
+  if (msg->status.status == sensor_msgs::msg::NavSatStatus::STATUS_NO_FIX) {
     trajectory_builder_->AddSensorData(
         sensor_id,
         carto::sensor::FixedFramePoseData{time, absl::optional<Rigid3d>()});
@@ -99,7 +99,7 @@ void SensorBridge::HandleNavSatFixMessage(
 
 void SensorBridge::HandleLandmarkMessage(
     const std::string& sensor_id,
-    const cartographer_ros_msgs::LandmarkList::ConstPtr& msg) {
+    const cartographer_ros_msgs::msg::LandmarkList::ConstSharedPtr& msg) {
   auto landmark_data = ToLandmarkData(*msg);
 
   auto tracking_from_landmark_sensor = tf_bridge_.LookupToTracking(
@@ -115,7 +115,7 @@ void SensorBridge::HandleLandmarkMessage(
 }
 
 std::unique_ptr<carto::sensor::ImuData> SensorBridge::ToImuData(
-    const sensor_msgs::Imu::ConstPtr& msg) {
+    const sensor_msgs::msg::Imu::ConstSharedPtr& msg) {
   CHECK_NE(msg->linear_acceleration_covariance[0], -1)
       << "Your IMU data claims to not contain linear acceleration measurements "
          "by setting linear_acceleration_covariance[0] to -1. Cartographer "
@@ -143,7 +143,7 @@ std::unique_ptr<carto::sensor::ImuData> SensorBridge::ToImuData(
 }
 
 void SensorBridge::HandleImuMessage(const std::string& sensor_id,
-                                    const sensor_msgs::Imu::ConstPtr& msg) {
+                                    const sensor_msgs::msg::Imu::ConstSharedPtr& msg) {
   std::unique_ptr<carto::sensor::ImuData> imu_data = ToImuData(msg);
   if (imu_data != nullptr) {
     trajectory_builder_->AddSensorData(
@@ -154,7 +154,7 @@ void SensorBridge::HandleImuMessage(const std::string& sensor_id,
 }
 
 void SensorBridge::HandleLaserScanMessage(
-    const std::string& sensor_id, const sensor_msgs::LaserScan::ConstPtr& msg) {
+    const std::string& sensor_id, const sensor_msgs::msg::LaserScan::ConstSharedPtr& msg) {
   carto::sensor::PointCloudWithIntensities point_cloud;
   carto::common::Time time;
   std::tie(point_cloud, time) = ToPointCloudWithIntensities(*msg);
@@ -163,7 +163,7 @@ void SensorBridge::HandleLaserScanMessage(
 
 void SensorBridge::HandleMultiEchoLaserScanMessage(
     const std::string& sensor_id,
-    const sensor_msgs::MultiEchoLaserScan::ConstPtr& msg) {
+    const sensor_msgs::msg::MultiEchoLaserScan::ConstSharedPtr& msg) {
   carto::sensor::PointCloudWithIntensities point_cloud;
   carto::common::Time time;
   std::tie(point_cloud, time) = ToPointCloudWithIntensities(*msg);
@@ -172,7 +172,7 @@ void SensorBridge::HandleMultiEchoLaserScanMessage(
 
 void SensorBridge::HandlePointCloud2Message(
     const std::string& sensor_id,
-    const sensor_msgs::PointCloud2::ConstPtr& msg) {
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr& msg) {
   carto::sensor::PointCloudWithIntensities point_cloud;
   carto::common::Time time;
   std::tie(point_cloud, time) = ToPointCloudWithIntensities(*msg);

--- a/cartographer_ros/cartographer_ros/sensor_bridge.h
+++ b/cartographer_ros/cartographer_ros/sensor_bridge.h
@@ -26,16 +26,16 @@
 #include "cartographer/transform/rigid_transform.h"
 #include "cartographer/transform/transform.h"
 #include "cartographer_ros/tf_bridge.h"
-#include "cartographer_ros_msgs/LandmarkList.h"
-#include "geometry_msgs/Transform.h"
-#include "geometry_msgs/TransformStamped.h"
-#include "nav_msgs/OccupancyGrid.h"
-#include "nav_msgs/Odometry.h"
-#include "sensor_msgs/Imu.h"
-#include "sensor_msgs/LaserScan.h"
-#include "sensor_msgs/MultiEchoLaserScan.h"
-#include "sensor_msgs/NavSatFix.h"
-#include "sensor_msgs/PointCloud2.h"
+#include "cartographer_ros_msgs/msg/landmark_list.hpp"
+#include <geometry_msgs/msg/transform.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <nav_msgs/msg/occupancy_grid.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+#include <sensor_msgs/msg/multi_echo_laser_scan.hpp>
+#include <sensor_msgs/msg/nav_sat_fix.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 
 namespace cartographer_ros {
 
@@ -51,26 +51,26 @@ class SensorBridge {
   SensorBridge& operator=(const SensorBridge&) = delete;
 
   std::unique_ptr<::cartographer::sensor::OdometryData> ToOdometryData(
-      const nav_msgs::Odometry::ConstPtr& msg);
+      const nav_msgs::msg::Odometry::ConstSharedPtr& msg);
   void HandleOdometryMessage(const std::string& sensor_id,
-                             const nav_msgs::Odometry::ConstPtr& msg);
+                             const nav_msgs::msg::Odometry::ConstSharedPtr& msg);
   void HandleNavSatFixMessage(const std::string& sensor_id,
-                              const sensor_msgs::NavSatFix::ConstPtr& msg);
+                              const sensor_msgs::msg::NavSatFix::ConstSharedPtr& msg);
   void HandleLandmarkMessage(
       const std::string& sensor_id,
-      const cartographer_ros_msgs::LandmarkList::ConstPtr& msg);
+      const cartographer_ros_msgs::msg::LandmarkList::ConstSharedPtr& msg);
 
   std::unique_ptr<::cartographer::sensor::ImuData> ToImuData(
-      const sensor_msgs::Imu::ConstPtr& msg);
+      const sensor_msgs::msg::Imu::ConstSharedPtr& msg);
   void HandleImuMessage(const std::string& sensor_id,
-                        const sensor_msgs::Imu::ConstPtr& msg);
+                        const sensor_msgs::msg::Imu::ConstSharedPtr& msg);
   void HandleLaserScanMessage(const std::string& sensor_id,
-                              const sensor_msgs::LaserScan::ConstPtr& msg);
+                              const sensor_msgs::msg::LaserScan::ConstSharedPtr& msg);
   void HandleMultiEchoLaserScanMessage(
       const std::string& sensor_id,
-      const sensor_msgs::MultiEchoLaserScan::ConstPtr& msg);
+      const sensor_msgs::msg::MultiEchoLaserScan::ConstSharedPtr& msg);
   void HandlePointCloud2Message(const std::string& sensor_id,
-                                const sensor_msgs::PointCloud2::ConstPtr& msg);
+                                const sensor_msgs::msg::PointCloud2::ConstSharedPtr& msg);
 
   const TfBridge& tf_bridge() const;
 

--- a/cartographer_ros/cartographer_ros/submap.h
+++ b/cartographer_ros/cartographer_ros/submap.h
@@ -25,7 +25,8 @@
 #include "cartographer/io/submap_painter.h"
 #include "cartographer/mapping/id.h"
 #include "cartographer/transform/rigid_transform.h"
-#include "ros/ros.h"
+#include "cartographer_ros_msgs/srv/submap_query.hpp"
+#include <rclcpp/rclcpp.hpp>
 
 namespace cartographer_ros {
 
@@ -33,7 +34,9 @@ namespace cartographer_ros {
 // on error.
 std::unique_ptr<::cartographer::io::SubmapTextures> FetchSubmapTextures(
     const ::cartographer::mapping::SubmapId& submap_id,
-    ros::ServiceClient* client);
+    rclcpp::Client<cartographer_ros_msgs::srv::SubmapQuery>::SharedPtr client,
+    rclcpp::executors::SingleThreadedExecutor::SharedPtr callback_group_executor,
+    const std::chrono::milliseconds timeout);
 
 }  // namespace cartographer_ros
 

--- a/cartographer_ros/cartographer_ros/tf_bridge.cc
+++ b/cartographer_ros/cartographer_ros/tf_bridge.cc
@@ -31,19 +31,20 @@ TfBridge::TfBridge(const std::string& tracking_frame,
 std::unique_ptr<::cartographer::transform::Rigid3d> TfBridge::LookupToTracking(
     const ::cartographer::common::Time time,
     const std::string& frame_id) const {
-  ::ros::Duration timeout(lookup_transform_timeout_sec_);
+  tf2::Duration timeout(tf2::durationFromSec(lookup_transform_timeout_sec_));
   std::unique_ptr<::cartographer::transform::Rigid3d> frame_id_to_tracking;
   try {
-    const ::ros::Time latest_tf_time =
+    const rclcpp::Time latest_tf_time =
         buffer_
-            ->lookupTransform(tracking_frame_, frame_id, ::ros::Time(0.),
+            ->lookupTransform(tracking_frame_, frame_id, ::rclcpp::Time(0.),
                               timeout)
             .header.stamp;
-    const ::ros::Time requested_time = ToRos(time);
+    const rclcpp::Time requested_time = ToRos(time);
+
     if (latest_tf_time >= requested_time) {
       // We already have newer data, so we do not wait. Otherwise, we would wait
       // for the full 'timeout' even if we ask for data that is too old.
-      timeout = ::ros::Duration(0.);
+      timeout = tf2::durationFromSec(0.0);
     }
     return absl::make_unique<::cartographer::transform::Rigid3d>(
         ToRigid3d(buffer_->lookupTransform(tracking_frame_, frame_id,

--- a/cartographer_ros/cartographer_ros/tf_bridge.h
+++ b/cartographer_ros/cartographer_ros/tf_bridge.h
@@ -21,7 +21,8 @@
 
 #include "cartographer/transform/rigid_transform.h"
 #include "cartographer_ros/time_conversion.h"
-#include "tf2_ros/buffer.h"
+#include <tf2_ros/buffer.h>
+#include <rclcpp/rclcpp.hpp>
 
 namespace cartographer_ros {
 

--- a/cartographer_ros/cartographer_ros/time_conversion.cc
+++ b/cartographer_ros/cartographer_ros/time_conversion.cc
@@ -17,31 +17,28 @@
 #include "cartographer_ros/time_conversion.h"
 
 #include "cartographer/common/time.h"
-#include "ros/ros.h"
+#include <builtin_interfaces/msg/time.hpp>
 
 namespace cartographer_ros {
 
-::ros::Time ToRos(::cartographer::common::Time time) {
+rclcpp::Time ToRos(::cartographer::common::Time time) {
   int64_t uts_timestamp = ::cartographer::common::ToUniversal(time);
   int64_t ns_since_unix_epoch =
       (uts_timestamp -
        ::cartographer::common::kUtsEpochOffsetFromUnixEpochInSeconds *
            10000000ll) *
       100ll;
-  ::ros::Time ros_time;
-  ros_time.fromNSec(ns_since_unix_epoch);
+  rclcpp::Time ros_time(ns_since_unix_epoch, rcl_clock_type_t::RCL_ROS_TIME);
   return ros_time;
 }
 
 // TODO(pedrofernandez): Write test.
-::cartographer::common::Time FromRos(const ::ros::Time& time) {
+::cartographer::common::Time FromRos(const rclcpp::Time& time) {
   // The epoch of the ICU Universal Time Scale is "0001-01-01 00:00:00.0 +0000",
   // exactly 719162 days before the Unix epoch.
   return ::cartographer::common::FromUniversal(
-      (time.sec +
-       ::cartographer::common::kUtsEpochOffsetFromUnixEpochInSeconds) *
-          10000000ll +
-      (time.nsec + 50) / 100);  // + 50 to get the rounding correct.
+      cartographer::common::kUtsEpochOffsetFromUnixEpochInSeconds * 10000000ll +
+      (time.nanoseconds() + 50) / 100);  // + 50 to get the rounding correct.
 }
 
 }  // namespace cartographer_ros

--- a/cartographer_ros/cartographer_ros/time_conversion.h
+++ b/cartographer_ros/cartographer_ros/time_conversion.h
@@ -18,13 +18,14 @@
 #define CARTOGRAPHER_ROS_CARTOGRAPHER_ROS_TIME_CONVERSION_H
 
 #include "cartographer/common/time.h"
-#include "ros/ros.h"
+#include <builtin_interfaces/msg/time.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 namespace cartographer_ros {
 
-::ros::Time ToRos(::cartographer::common::Time time);
+rclcpp::Time ToRos(::cartographer::common::Time time);
 
-::cartographer::common::Time FromRos(const ::ros::Time& time);
+::cartographer::common::Time FromRos(const rclcpp::Time& time);
 
 }  // namespace cartographer_ros
 

--- a/cartographer_ros/cartographer_ros/time_conversion_test.cc
+++ b/cartographer_ros/cartographer_ros/time_conversion_test.cc
@@ -29,7 +29,7 @@ TEST(TimeConversion, testToRos) {
   std::vector<int64_t> values = {0, 1469091375, 1466481821, 1462101382,
                                  1468238899};
   for (int64_t seconds_since_epoch : values) {
-    ::ros::Time ros_now;
+    builtin_interfaces::msg::Time ros_now;
     ros_now.fromSec(seconds_since_epoch);
     ::cartographer::common::Time cartographer_now(
         ::cartographer::common::FromSeconds(

--- a/cartographer_ros/cartographer_ros/urdf_reader.cc
+++ b/cartographer_ros/cartographer_ros/urdf_reader.cc
@@ -24,8 +24,8 @@
 
 namespace cartographer_ros {
 
-std::vector<geometry_msgs::TransformStamped> ReadStaticTransformsFromUrdf(
-    const std::string& urdf_filename, tf2_ros::Buffer* const tf_buffer) {
+std::vector<geometry_msgs::msg::TransformStamped> ReadStaticTransformsFromUrdf(
+    const std::string& urdf_filename, std::shared_ptr<tf2_ros::Buffer> tf_buffer) {
   urdf::Model model;
   CHECK(model.initFile(urdf_filename));
 #if URDFDOM_HEADERS_HAS_SHARED_PTR_DEFS
@@ -34,7 +34,7 @@ std::vector<geometry_msgs::TransformStamped> ReadStaticTransformsFromUrdf(
   std::vector<boost::shared_ptr<urdf::Link> > links;
 #endif
   model.getLinks(links);
-  std::vector<geometry_msgs::TransformStamped> transforms;
+  std::vector<geometry_msgs::msg::TransformStamped> transforms;
   for (const auto& link : links) {
     if (!link->getParent() || link->parent_joint->type != urdf::Joint::FIXED) {
       continue;
@@ -42,7 +42,7 @@ std::vector<geometry_msgs::TransformStamped> ReadStaticTransformsFromUrdf(
 
     const urdf::Pose& pose =
         link->parent_joint->parent_to_joint_origin_transform;
-    geometry_msgs::TransformStamped transform;
+    geometry_msgs::msg::TransformStamped transform;
     transform.transform =
         ToGeometryMsgTransform(cartographer::transform::Rigid3d(
             Eigen::Vector3d(pose.position.x, pose.position.y, pose.position.z),

--- a/cartographer_ros/cartographer_ros/urdf_reader.h
+++ b/cartographer_ros/cartographer_ros/urdf_reader.h
@@ -24,8 +24,8 @@
 
 namespace cartographer_ros {
 
-std::vector<geometry_msgs::TransformStamped> ReadStaticTransformsFromUrdf(
-    const std::string& urdf_filename, tf2_ros::Buffer* tf_buffer);
+std::vector<geometry_msgs::msg::TransformStamped> ReadStaticTransformsFromUrdf(
+    const std::string& urdf_filename, std::shared_ptr<tf2_ros::Buffer> tf_buffer);
 
 }  // namespace cartographer_ros
 

--- a/cartographer_ros/package.xml
+++ b/cartographer_ros/package.xml
@@ -15,9 +15,9 @@
   limitations under the License.
 -->
 
-<package format="2">
+<package format="3">
   <name>cartographer_ros</name>
-  <version>1.0.0</version>
+  <version>2.0.0</version>
   <description>
     Cartographer is a system that provides real-time simultaneous localization
     and mapping (SLAM) in 2D and 3D across multiple platforms and sensor
@@ -34,15 +34,16 @@
     The Cartographer Authors
   </author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>git</build_depend>
   <build_depend>google-mock</build_depend>
   <build_depend>protobuf-dev</build_depend>
   <build_depend>python3-sphinx</build_depend>
 
-  <depend version_gte="1.0.0">cartographer</depend>
-  <depend version_gte="1.0.0">cartographer_ros_msgs</depend>
+<!--  <depend>backward_ros</depend>-->
+  <depend>cartographer</depend>
+  <depend>cartographer_ros_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>libgflags-dev</depend>
   <depend>libgoogle-glog-dev</depend>
@@ -63,9 +64,7 @@
   <depend>urdf</depend>
   <depend>visualization_msgs</depend>
 
-  <test_depend>rosunit</test_depend>
-
   <export>
-      <rviz plugin="${prefix}/rviz_plugin_description.xml" />
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/cartographer_ros_msgs/CMakeLists.txt
+++ b/cartographer_ros_msgs/CMakeLists.txt
@@ -12,54 +12,61 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 
 project(cartographer_ros_msgs)
 
-set(PACKAGE_DEPENDENCIES
-  geometry_msgs
-  std_msgs
+# Default to C++14.
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # We don't use add_compile_options with pedantic in message packages
+  # because the Python C extensions don't comply with it.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+find_package(builtin_interfaces REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+
+set(msg_files
+  "msg/BagfileProgress.msg"
+  "msg/HistogramBucket.msg"
+  "msg/LandmarkEntry.msg"
+  "msg/LandmarkList.msg"
+  "msg/MetricFamily.msg"
+  "msg/MetricLabel.msg"
+  "msg/Metric.msg"
+  "msg/StatusCode.msg"
+  "msg/StatusResponse.msg"
+  "msg/SubmapEntry.msg"
+  "msg/SubmapList.msg"
+  "msg/SubmapTexture.msg"
+  "msg/TrajectoryStates.msg"
 )
 
-find_package(catkin REQUIRED COMPONENTS message_generation ${PACKAGE_DEPENDENCIES})
-
-add_message_files(
-  DIRECTORY msg
-  FILES
-    BagfileProgress.msg
-    HistogramBucket.msg
-    LandmarkEntry.msg
-    LandmarkList.msg
-    MetricFamily.msg
-    MetricLabel.msg
-    Metric.msg
-    StatusCode.msg
-    StatusResponse.msg
-    SubmapEntry.msg
-    SubmapList.msg
-    SubmapTexture.msg
-    TrajectoryStates.msg
+set(srv_files
+  "srv/FinishTrajectory.srv"
+  "srv/GetTrajectoryStates.srv"
+  "srv/ReadMetrics.srv"
+  "srv/StartTrajectory.srv"
+  "srv/TrajectoryQuery.srv"
+  "srv/SubmapQuery.srv"
+  "srv/WriteState.srv"
 )
 
-add_service_files(
-  DIRECTORY srv
-  FILES
-    FinishTrajectory.srv
-    GetTrajectoryStates.srv
-    ReadMetrics.srv
-    StartTrajectory.srv
-    SubmapQuery.srv
-    TrajectoryQuery.srv
-    WriteState.srv
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  ${srv_files}
+  DEPENDENCIES geometry_msgs std_msgs
+  ADD_LINTER_TESTS
 )
 
-generate_messages(
-  DEPENDENCIES
-    ${PACKAGE_DEPENDENCIES}
-)
+ament_export_dependencies(rosidl_default_runtime)
 
-catkin_package(
-  CATKIN_DEPENDS
-    ${PACKAGE_DEPENDENCIES}
-    message_runtime
-)
+ament_package()

--- a/cartographer_ros_msgs/package.xml
+++ b/cartographer_ros_msgs/package.xml
@@ -15,7 +15,7 @@
   limitations under the License.
 -->
 
-<package format="2">
+<package format="3">
   <name>cartographer_ros_msgs</name>
   <version>1.0.0</version>
   <description>
@@ -32,12 +32,20 @@
     The Cartographer Authors
   </author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
 
-  <build_depend>message_generation</build_depend>
-  
-  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/cartographer_ros_msgs/srv/ReadMetrics.srv
+++ b/cartographer_ros_msgs/srv/ReadMetrics.srv
@@ -15,4 +15,4 @@
 ---
 cartographer_ros_msgs/StatusResponse status
 cartographer_ros_msgs/MetricFamily[] metric_families
-time timestamp
+builtin_interfaces/Time timestamp

--- a/cartographer_rviz/CMakeLists.txt
+++ b/cartographer_rviz/CMakeLists.txt
@@ -14,97 +14,97 @@
 
 cmake_minimum_required(VERSION 2.8.12)  # Ships with Ubuntu 14.04 (Trusty)
 
-project(cartographer_rviz)
+#project(cartographer_rviz)
 
-set(PACKAGE_DEPENDENCIES
-  cartographer_ros
-  cartographer_ros_msgs
-  message_runtime
-  roscpp
-  roslib
-  rviz
-)
+#set(PACKAGE_DEPENDENCIES
+#  cartographer_ros
+#  cartographer_ros_msgs
+#  message_runtime
+#  roscpp
+#  roslib
+#  rviz
+#)
 
-if(WIN32)
-  set(Boost_USE_STATIC_LIBS FALSE)
-endif()
-find_package(Boost REQUIRED COMPONENTS system iostreams)
-find_package(cartographer REQUIRED)
-include("${CARTOGRAPHER_CMAKE_DIR}/functions.cmake")
-google_initialize_cartographer_project()
+#if(WIN32)
+#  set(Boost_USE_STATIC_LIBS FALSE)
+#endif()
+#find_package(Boost REQUIRED COMPONENTS system iostreams)
+#find_package(cartographer REQUIRED)
+#include("${CARTOGRAPHER_CMAKE_DIR}/functions.cmake")
+#google_initialize_cartographer_project()
 
-find_package(absl REQUIRED)
-find_package(Eigen3 REQUIRED)
-find_package(catkin REQUIRED COMPONENTS ${PACKAGE_DEPENDENCIES})
+#find_package(absl REQUIRED)
+#find_package(Eigen3 REQUIRED)
+#find_package(catkin REQUIRED COMPONENTS ${PACKAGE_DEPENDENCIES})
 
-catkin_package(
-  CATKIN_DEPENDS
-    message_runtime
-    ${PACKAGE_DEPENDENCIES}
-  INCLUDE_DIRS "."
-)
+#catkin_package(
+#  CATKIN_DEPENDS
+#    message_runtime
+#    ${PACKAGE_DEPENDENCIES}
+#  INCLUDE_DIRS "."
+#)
 
-file(GLOB_RECURSE ALL_SRCS "cartographer_rviz/*.cc" "cartographer_rviz/*.h")
-set(CMAKE_AUTOMOC ON)
+#file(GLOB_RECURSE ALL_SRCS "cartographer_rviz/*.cc" "cartographer_rviz/*.h")
+#set(CMAKE_AUTOMOC ON)
 
-if(rviz_QT_VERSION VERSION_LESS "5")
-  message(STATUS "Using Qt4 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-  find_package(Qt4 ${rviz_QT_VERSION} EXACT REQUIRED QtCore QtGui)
-  include(${QT_USE_FILE})
-else()
-  message(STATUS "Using Qt5 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-  find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
-  set(QT_LIBRARIES Qt5::Core Qt5::Widgets)
-  include_directories(${Qt5Widgets_INCLUDE_DIRS})
-endif()
-add_definitions(-DQT_NO_KEYWORDS)
-add_library(${PROJECT_NAME} ${ALL_SRCS})
-target_link_libraries(${PROJECT_NAME} PUBLIC ${QT_LIBRARIES})
+#if(rviz_QT_VERSION VERSION_LESS "5")
+#  message(STATUS "Using Qt4 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
+#  find_package(Qt4 ${rviz_QT_VERSION} EXACT REQUIRED QtCore QtGui)
+#  include(${QT_USE_FILE})
+#else()
+#  message(STATUS "Using Qt5 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
+#  find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+#  set(QT_LIBRARIES Qt5::Core Qt5::Widgets)
+#  include_directories(${Qt5Widgets_INCLUDE_DIRS})
+#endif()
+#add_definitions(-DQT_NO_KEYWORDS)
+#add_library(${PROJECT_NAME} ${ALL_SRCS})
+#target_link_libraries(${PROJECT_NAME} PUBLIC ${QT_LIBRARIES})
 
-# Add the binary directory first, so that port.h is included after it has
-# been generated.
-target_include_directories(${PROJECT_NAME} PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include>
-)
+## Add the binary directory first, so that port.h is included after it has
+## been generated.
+#target_include_directories(${PROJECT_NAME} PUBLIC
+#    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+#    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+#    $<INSTALL_INTERFACE:include>
+#)
 
-target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
-  "${EIGEN3_INCLUDE_DIR}")
-target_link_libraries(${PROJECT_NAME} PUBLIC ${EIGEN3_LIBRARIES})
+#target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
+#  "${EIGEN3_INCLUDE_DIR}")
+#target_link_libraries(${PROJECT_NAME} PUBLIC ${EIGEN3_LIBRARIES})
 
-target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
-  "${Boost_INCLUDE_DIRS}")
-target_link_libraries(${PROJECT_NAME} PUBLIC ${Boost_LIBRARIES})
+#target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
+#  "${Boost_INCLUDE_DIRS}")
+#target_link_libraries(${PROJECT_NAME} PUBLIC ${Boost_LIBRARIES})
 
-target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${catkin_INCLUDE_DIRS})
-target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES})
-add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+#target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${catkin_INCLUDE_DIRS})
+#target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES})
+#add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 
-set(TARGET_COMPILE_FLAGS "${TARGET_COMPILE_FLAGS} ${GOOG_CXX_FLAGS}")
-set_target_properties(${PROJECT_NAME} PROPERTIES
-  COMPILE_FLAGS ${TARGET_COMPILE_FLAGS})
+#set(TARGET_COMPILE_FLAGS "${TARGET_COMPILE_FLAGS} ${GOOG_CXX_FLAGS}")
+#set_target_properties(${PROJECT_NAME} PROPERTIES
+#  COMPILE_FLAGS ${TARGET_COMPILE_FLAGS})
 
-target_link_libraries(${PROJECT_NAME} PUBLIC cartographer)
+#target_link_libraries(${PROJECT_NAME} PUBLIC cartographer)
 
-# On windows, rviz won't find the DLL in CATKIN_PACKAGE_BIN_DESTINATION,
-# but it will in CATKIN_PACKAGE_LIB_DESTINATION?
-if(WIN32)
-  set(RUNTIME_DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
-else()
-  set(RUNTIME_DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-endif()
+## On windows, rviz won't find the DLL in CATKIN_PACKAGE_BIN_DESTINATION,
+## but it will in CATKIN_PACKAGE_LIB_DESTINATION?
+#if(WIN32)
+#  set(RUNTIME_DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+#else()
+#  set(RUNTIME_DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+#endif()
 
-install(TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${RUNTIME_DESTINATION}
-)
+#install(TARGETS ${PROJECT_NAME}
+#  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#  RUNTIME DESTINATION ${RUNTIME_DESTINATION}
+#)
 
-install(FILES rviz_plugin_description.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
+#install(FILES rviz_plugin_description.xml
+#  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+#)
 
-install(DIRECTORY ogre_media
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
+#install(DIRECTORY ogre_media
+#  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+#)


### PR DESCRIPTION
I needed an updated ros2 wrapper compiling against rolling/galactic, so here it is. I started from the master branch but took inspiration from https://github.com/ros2/cartographer_ros when needed.
Still a wip but the main nodes are working. Would be nice to target a galactic release.

Converted to this point (06/05/2021):

- **cartographer_node**, tested with a real robot for 2D mapping with a 2D lidar and wheel odometry, no IMU
- **cartographer_occupancy_grid_node**, working
- **cartographer_offline_node**, tested with a bag and same config as **cartographer_node**. Don't forget to start with `use_sim_time` to true to get a common time reference between recorded tf, carto generated tf and sensors. I struggled more than I expected with the (new to me) rosbag2 cpp interface so it is probably sub-optimal at this point
- **cartographer_assets_writer**, same as above
- **cartographer_pbstream_map_publisher**, working
- **cartographer_pbstream_to_ros_map**, working
- **cartographer_rosbag_validate**, working
- `cartographer_ros_msgs` package

Still to do but less critical:
- dev and grpc nodes
- test nodes
- `cartographer_rviz` package (would be _really_ nice to have)
- Clean the CMakelists
- Unify code style (and decide for one)
- Changelogs and authors update

