### PR TITLE
Add option to ignore out of order sensor message

### DIFF
--- a/cartographer_ros/cartographer_ros/map_builder_bridge.cc
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.cc
@@ -138,6 +138,7 @@ int MapBuilderBridge::AddTrajectory(
   CHECK_EQ(sensor_bridges_.count(trajectory_id), 0);
   sensor_bridges_[trajectory_id] = absl::make_unique<SensorBridge>(
       trajectory_options.num_subdivisions_per_laser_scan,
+      trajectory_options.ignore_out_of_order_messages,
       trajectory_options.tracking_frame,
       node_options_.lookup_transform_timeout_sec, tf_buffer_,
       map_builder_->GetTrajectoryBuilder(trajectory_id));

--- a/cartographer_ros/cartographer_ros/node.cc
+++ b/cartographer_ros/cartographer_ros/node.cc
@@ -771,7 +771,8 @@ void Node::HandleOdometryMessage(const int trajectory_id,
   }
   auto sensor_bridge_ptr = map_builder_bridge_.sensor_bridge(trajectory_id);
   auto odometry_data_ptr = sensor_bridge_ptr->ToOdometryData(msg);
-  if (odometry_data_ptr != nullptr) {
+  if (odometry_data_ptr != nullptr &&
+      !sensor_bridge_ptr->IgnoreMessage(sensor_id, odometry_data_ptr->time)) {
     extrapolators_.at(trajectory_id).AddOdometryData(*odometry_data_ptr);
   }
   sensor_bridge_ptr->HandleOdometryMessage(sensor_id, msg);
@@ -808,7 +809,8 @@ void Node::HandleImuMessage(const int trajectory_id,
   }
   auto sensor_bridge_ptr = map_builder_bridge_.sensor_bridge(trajectory_id);
   auto imu_data_ptr = sensor_bridge_ptr->ToImuData(msg);
-  if (imu_data_ptr != nullptr) {
+  if (imu_data_ptr != nullptr &&
+      !sensor_bridge_ptr->IgnoreMessage(sensor_id, imu_data_ptr->time)) {
     extrapolators_.at(trajectory_id).AddImuData(*imu_data_ptr);
   }
   sensor_bridge_ptr->HandleImuMessage(sensor_id, msg);

--- a/cartographer_ros/cartographer_ros/sensor_bridge.h
+++ b/cartographer_ros/cartographer_ros/sensor_bridge.h
@@ -43,8 +43,9 @@ namespace cartographer_ros {
 class SensorBridge {
  public:
   explicit SensorBridge(
-      int num_subdivisions_per_laser_scan, const std::string& tracking_frame,
-      double lookup_transform_timeout_sec, tf2_ros::Buffer* tf_buffer,
+      int num_subdivisions_per_laser_scan, bool ignore_out_of_order_messages,
+      const std::string& tracking_frame, double lookup_transform_timeout_sec,
+      tf2_ros::Buffer* tf_buffer,
       ::cartographer::mapping::TrajectoryBuilderInterface* trajectory_builder);
 
   SensorBridge(const SensorBridge&) = delete;
@@ -73,6 +74,8 @@ class SensorBridge {
                                 const sensor_msgs::PointCloud2::ConstPtr& msg);
 
   const TfBridge& tf_bridge() const;
+  bool IgnoreMessage(const std::string& sensor_id,
+                     ::cartographer::common::Time sensor_time);
 
  private:
   void HandleLaserScan(
@@ -85,8 +88,10 @@ class SensorBridge {
                          const ::cartographer::sensor::TimedPointCloud& ranges);
 
   const int num_subdivisions_per_laser_scan_;
+  const bool ignore_out_of_order_messages_;
   std::map<std::string, cartographer::common::Time>
       sensor_to_previous_subdivision_time_;
+  std::map<std::string, cartographer::common::Time> latest_sensor_time_;
   const TfBridge tf_bridge_;
   ::cartographer::mapping::TrajectoryBuilderInterface* const
       trajectory_builder_;

--- a/cartographer_ros/cartographer_ros/trajectory_options.cc
+++ b/cartographer_ros/cartographer_ros/trajectory_options.cc
@@ -76,6 +76,12 @@ TrajectoryOptions CreateTrajectoryOptions(
       lua_parameter_dictionary->GetDouble("imu_sampling_ratio");
   options.landmarks_sampling_ratio =
       lua_parameter_dictionary->GetDouble("landmarks_sampling_ratio");
+  if (lua_parameter_dictionary->HasKey("ignore_out_of_order")) {
+    options.ignore_out_of_order_messages =
+        lua_parameter_dictionary->GetBool("ignore_out_of_order");
+  } else {
+    options.ignore_out_of_order_messages = false;
+  }
   CheckTrajectoryOptions(options);
   return options;
 }

--- a/cartographer_ros/cartographer_ros/trajectory_options.h
+++ b/cartographer_ros/cartographer_ros/trajectory_options.h
@@ -36,6 +36,7 @@ struct TrajectoryOptions {
   bool use_nav_sat;
   bool use_landmarks;
   bool publish_frame_projected_to_2d;
+  bool ignore_out_of_order_messages;
   int num_laser_scans;
   int num_multi_echo_laser_scans;
   int num_subdivisions_per_laser_scan;


### PR DESCRIPTION
Add option `ignore_out_of_order_message` to ignore IMU/Odometry/Rangefinder messages if they arrive out of order.

Default behavior is to dispatch these messages which leads to crash in cartographer. This allows users to ignore those messages and generate warnings instead. 

Signed-off-by: Linh Nguyen <linh.nguyen@enway.ai>
