### PR TITLE
Fix build error on Ubuntu 20.04 + ROS Noetic/Melodic

### DIFF
--- a/Dockerfile.melodic
+++ b/Dockerfile.melodic
@@ -32,7 +32,8 @@ ADD https://api.github.com/repos/cartographer-project/cartographer/git/refs/head
 COPY cartographer_ros.rosinstall cartographer_ros/
 COPY scripts/prepare_catkin_workspace.sh cartographer_ros/scripts/
 RUN CARTOGRAPHER_VERSION=$CARTOGRAPHER_VERSION \
-    cartographer_ros/scripts/prepare_catkin_workspace.sh
+    cartographer_ros/scripts/prepare_catkin_workspace.sh && \
+    sed -i -e "s%<depend>libabsl-dev</depend>%<\!--<depend>libabsl-dev</depend>-->%g" catkin_ws/src/cartographer/package.xml
 
 # rosdep needs the updated package.xml files to install the correct debs.
 COPY cartographer_ros/package.xml catkin_ws/src/cartographer_ros/cartographer_ros/

--- a/Dockerfile.noetic
+++ b/Dockerfile.noetic
@@ -36,7 +36,8 @@ ADD https://api.github.com/repos/cartographer-project/cartographer/git/refs/head
 COPY cartographer_ros.rosinstall cartographer_ros/
 COPY scripts/prepare_catkin_workspace.sh cartographer_ros/scripts/
 RUN CARTOGRAPHER_VERSION=$CARTOGRAPHER_VERSION \
-    cartographer_ros/scripts/prepare_catkin_workspace.sh
+    cartographer_ros/scripts/prepare_catkin_workspace.sh && \
+    sed -i -e "s%<depend>libabsl-dev</depend>%<\!--<depend>libabsl-dev</depend>-->%g" catkin_ws/src/cartographer/package.xml
 
 # rosdep needs the updated package.xml files to install the correct debs.
 COPY cartographer_ros/package.xml catkin_ws/src/cartographer_ros/cartographer_ros/


### PR DESCRIPTION
## Proposed change

This PR fixes the following error on docker build.

```
rosdep install --from-paths src --ignore-src --rosdistro=${ROS_DISTRO} -y
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
cartographer: [libabsl-dev] defined as "not available" for OS version [focal]
```

related issue/PR:

* https://github.com/cartographer-project/cartographer_ros/issues/1726
* https://github.com/cartographer-project/cartographer/pull/1875

## Testing and Verification
### Test Configuration:
- Ubuntu 20.04.4
- Docker version 20.10.14, build a224086

### Procedure:

1. `docker build -t cartographer:noetic -f Dockerfile.noetic .`
1. `docker build -t cartographer:melodic -f Dockerfile.melodic .`